### PR TITLE
doc: fix link to npm for the WASM/TypeScript/JavaScript implementation

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -1,6 +1,6 @@
 # Buttplug Rust FFI - WASM/Typescript/Javascript
 
-[![NPM](https://img.shields.io/nuget/v/Buttplug.svg)](https://www.nuget.org/packages/Buttplug/)
+[![NPM](https://img.shields.io/npm/v/buttplug.svg)](https://www.npmjs.com/package/buttplug)
 
 [![Patreon donate button](https://img.shields.io/badge/patreon-donate-yellow.svg)](https://www.patreon.com/qdot)
 [![Discourse Forum](https://img.shields.io/badge/discourse-forum-blue.svg)](https://metafetish.club)


### PR DESCRIPTION
The link and the badge was pointing to Nuget instead of NPM