### PR TITLE
Rename functions that deal with protobuf

### DIFF
--- a/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
@@ -52,19 +52,19 @@ namespace Buttplug
     internal class ButtplugFFICalls
     {
         [DllImport("buttplug_rs_ffi")]
-        internal static extern ButtplugFFIClientHandle buttplug_create_client(string client_name, ButtplugCallback callback, IntPtr ctx);
+        internal static extern ButtplugFFIClientHandle buttplug_create_protobuf_client(string client_name, ButtplugCallback callback, IntPtr ctx);
 
         [DllImport("buttplug_rs_ffi")]
         internal static extern void buttplug_free_client(IntPtr client_handle);
 
         [DllImport("buttplug_rs_ffi")]
-        internal static extern void buttplug_parse_client_message(ButtplugFFIClientHandle client_handle, byte[] buf, int buf_length, ButtplugCallback callback, IntPtr ctx);
+        internal static extern void buttplug_client_protobuf_message(ButtplugFFIClientHandle client_handle, byte[] buf, int buf_length, ButtplugCallback callback, IntPtr ctx);
 
         [DllImport("buttplug_rs_ffi")]
         internal static extern ButtplugFFIDeviceHandle buttplug_create_device(ButtplugFFIClientHandle client_handle, uint device_index);
 
         [DllImport("buttplug_rs_ffi")]
-        internal static extern void buttplug_parse_device_message(ButtplugFFIDeviceHandle client_handle, byte[] buf, int buf_length, ButtplugCallback callback, IntPtr ctx);
+        internal static extern void buttplug_device_protobuf_message(ButtplugFFIDeviceHandle client_handle, byte[] buf, int buf_length, ButtplugCallback callback, IntPtr ctx);
 
         [DllImport("buttplug_rs_ffi")]
         internal static extern void buttplug_free_device(IntPtr device_handle);
@@ -77,14 +77,14 @@ namespace Buttplug
     {
         internal static ButtplugFFIClientHandle SendCreateClient(string aClientName, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            return ButtplugFFICalls.buttplug_create_client(aClientName, aCallback, aCallbackCtx);
+            return ButtplugFFICalls.buttplug_create_protobuf_client(aClientName, aCallback, aCallbackCtx);
         }
 
         internal static Task<ButtplugFFIServerMessage> SendClientMessage(ButtplugFFIMessageSorter aSorter, ButtplugFFIClientHandle aHandle, ClientMessage aMsg, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
             var task = aSorter.PrepareClientMessage(aMsg);
             var buf = aMsg.ToByteArray();
-            ButtplugFFICalls.buttplug_parse_client_message(aHandle, buf, buf.Length, aCallback, aCallbackCtx);
+            ButtplugFFICalls.buttplug_client_protobuf_message(aHandle, buf, buf.Length, aCallback, aCallbackCtx);
             return task;
         }
 
@@ -182,7 +182,7 @@ namespace Buttplug
         {
             var task = aSorter.PrepareDeviceMessage(aMsg);
             var buf = aMsg.ToByteArray();
-            ButtplugFFICalls.buttplug_parse_device_message(aHandle, buf, buf.Length, aCallback, aCallbackCtx);
+            ButtplugFFICalls.buttplug_device_protobuf_message(aHandle, buf, buf.Length, aCallback, aCallbackCtx);
             return task;
         }
 

--- a/ffi/src/export.rs
+++ b/ffi/src/export.rs
@@ -37,7 +37,7 @@ fn get_or_create_runtime() -> Arc<Runtime> {
 }
 
 #[no_mangle]
-pub extern "C" fn buttplug_create_client(
+pub extern "C" fn buttplug_create_protobuf_client(
   client_name_ptr: *const c_char,
   callback: FFICallback,
   callback_context: FFICallbackContext
@@ -64,7 +64,7 @@ pub extern "C" fn buttplug_free_client(ptr: *mut ButtplugFFIClient) {
 }
 
 #[no_mangle]
-pub extern "C" fn buttplug_parse_client_message(
+pub extern "C" fn buttplug_client_protobuf_message(
   client_ptr: *mut ButtplugFFIClient,
   buf: *const u8,
   buf_len: i32,
@@ -99,7 +99,7 @@ pub extern "C" fn buttplug_create_device(
 }
 
 #[no_mangle]
-pub extern "C" fn buttplug_parse_device_message(
+pub extern "C" fn buttplug_device_protobuf_message(
   device_ptr: *mut ButtplugFFIDevice,
   buf: *const u8,
   buf_len: i32,

--- a/ffi/src/export_wasm.rs
+++ b/ffi/src/export_wasm.rs
@@ -13,7 +13,7 @@ use console_error_panic_hook;
 
 #[no_mangle]
 #[wasm_bindgen]
-pub fn buttplug_create_client(
+pub fn buttplug_create_protobuf_client(
   client_name: &str,
   callback: &FFICallback,
   callback_context: u32
@@ -37,7 +37,7 @@ pub fn buttplug_free_client(ptr: *mut ButtplugFFIClient) {
 
 #[no_mangle]
 #[wasm_bindgen]
-pub fn buttplug_parse_client_message(
+pub fn buttplug_client_protobuf_message(
   client_ptr: *mut ButtplugFFIClient,
   buf: &[u8],
   callback: FFICallback,
@@ -69,7 +69,7 @@ pub fn buttplug_create_device(
 
 #[no_mangle]
 #[wasm_bindgen]
-pub fn buttplug_parse_device_message(
+pub fn buttplug_device_protobuf_message(
   device_ptr: *mut ButtplugFFIDevice,
   buf: &[u8],
   callback: FFICallback,

--- a/js/src/ffi.ts
+++ b/js/src/ffi.ts
@@ -18,15 +18,15 @@ function must_run_init_3(a: any | undefined, b: any | undefined, c: any | undefi
 function must_run_init_4(a: any | undefined, b: any | undefined, c: any | undefined, d: any | undefined): any {
   throw new Error("Must run buttplugInit() async before calling any Buttplug methods!");
 }
-// import { buttplug_create_client, buttplug_free_client, buttplug_parse_client_message, buttplug_activate_env_logger, buttplug_free_device, buttplug_create_device, buttplug_parse_device_message } from "./buttplug-rs-ffi/buttplug_rs_ffi";
+// import { buttplug_create_protobuf_client, buttplug_free_client, buttplug_client_protobuf_message, buttplug_activate_env_logger, buttplug_free_device, buttplug_create_device, buttplug_device_protobuf_message } from "./buttplug-rs-ffi/buttplug_rs_ffi";
 
-let buttplug_create_client = must_run_init_3;
+let buttplug_create_protobuf_client = must_run_init_3;
 let buttplug_free_client = must_run_init_1;
-let buttplug_parse_client_message = must_run_init_4;
+let buttplug_client_protobuf_message = must_run_init_4;
 let buttplug_activate_env_logger = must_run_init_1;
 let buttplug_free_device = must_run_init_1;
 let buttplug_create_device = must_run_init_2;
-let buttplug_parse_device_message = must_run_init_4;
+let buttplug_device_protobuf_message = must_run_init_4;
 let buttplug_has_init_run = false;
 
 export async function buttplugInit() {
@@ -38,20 +38,20 @@ export async function buttplugInit() {
     console.log(e);
     return Promise.reject(e);
   });
-  buttplug_create_client = index.buttplug_create_client;
+  buttplug_create_protobuf_client = index.buttplug_create_protobuf_client;
   buttplug_free_client = index.buttplug_free_client;
-  buttplug_parse_client_message = index.buttplug_parse_client_message;
+  buttplug_client_protobuf_message = index.buttplug_client_protobuf_message;
   buttplug_activate_env_logger = index.buttplug_activate_env_logger;
   buttplug_free_device = index.buttplug_free_device;
   buttplug_create_device = index.buttplug_create_device;
-  buttplug_parse_device_message = index.buttplug_parse_device_message;
+  buttplug_device_protobuf_message = index.buttplug_device_protobuf_message;
   buttplug_has_init_run = true;
 }
 
 function sendClientMessage(sorter: ButtplugMessageSorter, clientPtr: number, message: Buttplug.ClientMessage, callback: Function): Promise<Buttplug.ButtplugFFIServerMessage> {
   let promise = sorter.PrepareOutgoingMessage(message);
   let buffer = Buffer.from(Buttplug.ClientMessage.encode(message).finish())
-  buttplug_parse_client_message(clientPtr, buffer, callback, 0);
+  buttplug_client_protobuf_message(clientPtr, buffer, callback, 0);
   return promise;
 }
 
@@ -126,7 +126,7 @@ export function stopAllDevices(sorter: ButtplugMessageSorter, clientPtr: number,
 function sendDeviceMessage(sorter: ButtplugMessageSorter, devicePtr: number, message: Buttplug.DeviceMessage, callback: Function): Promise<Buttplug.ButtplugFFIServerMessage> {
   let promise = sorter.PrepareOutgoingMessage(message);
   let buffer = Buffer.from(Buttplug.DeviceMessage.encode(message).finish())
-  buttplug_parse_device_message(devicePtr, buffer, callback, 0);
+  buttplug_device_protobuf_message(devicePtr, buffer, callback, 0);
   return promise;
 }
 
@@ -252,7 +252,7 @@ export function rawUnsubscribe(sorter: ButtplugMessageSorter, devicePtr: number,
 }
 
 export function createClientPtr(eventCallback: Function, clientName: string): number {
-  return buttplug_create_client(clientName, eventCallback, 0);
+  return buttplug_create_protobuf_client(clientName, eventCallback, 0);
 }
 
 export function createDevicePtr(clientPtr: number, deviceIndex: number): number | null {


### PR DESCRIPTION
Closes #64

While working on this, I noticed:
 - buttplug_create_log_handle doesn't take a context parameter for the callback? this may be intentional, and it's okay if it is.
 - the wasm exports still have the old log handling

Potential suggestion: instead of create_protobuf_client, maybe there could be a separate "attach system callback to client" function?

feel free to close or edit if the names don't quite fit.