### PR TITLE
C# code cleanup

### DIFF
--- a/csharp/ButtplugCSharpFFI/ButtplugClient.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClient.cs
@@ -8,8 +8,8 @@ namespace Buttplug
 {
     public class ButtplugClient : IDisposable
     {
-        private static Dictionary<uint, WeakReference> _clientStorage = new Dictionary<uint, WeakReference>();
-        private static uint _clientCounter = 1;
+        private readonly static Dictionary<uint, WeakReference> _clientStorage = new Dictionary<uint, WeakReference>();
+        private readonly static uint _clientCounter = 1;
 
         /// <summary>
         /// Name of the client, used for server UI/permissions.
@@ -18,9 +18,9 @@ namespace Buttplug
 
         public bool Connected { get; private set; } = false;
 
-        private ButtplugFFIMessageSorter _messageSorter = new ButtplugFFIMessageSorter();
+        private readonly ButtplugFFIMessageSorter _messageSorter = new ButtplugFFIMessageSorter();
 
-        private ButtplugFFIClientHandle _clientHandle;
+        private readonly ButtplugFFIClientHandle _clientHandle;
 
         /// <summary>
         /// Event fired on Buttplug device added, either after connect or while scanning for devices.
@@ -64,7 +64,7 @@ namespace Buttplug
 
         public ButtplugClientDevice[] Devices => _devices.Values.ToArray();
 
-        private ButtplugCallback SorterCallbackDelegate;
+        private readonly ButtplugCallback SorterCallbackDelegate;
 
         // To detect redundant calls
         private bool _disposed = false;

--- a/csharp/ButtplugCSharpFFI/ButtplugClient.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClient.cs
@@ -8,8 +8,8 @@ namespace Buttplug
 {
     public class ButtplugClient : IDisposable
     {
-        static Dictionary<uint, WeakReference> _clientStorage = new Dictionary<uint, WeakReference>();
-        static uint _clientCounter = 1;
+        private static Dictionary<uint, WeakReference> _clientStorage = new Dictionary<uint, WeakReference>();
+        private static uint _clientCounter = 1;
 
         /// <summary>
         /// Name of the client, used for server UI/permissions.

--- a/csharp/ButtplugCSharpFFI/ButtplugClient.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClient.cs
@@ -14,7 +14,7 @@ namespace Buttplug
         /// <summary>
         /// Name of the client, used for server UI/permissions.
         /// </summary>
-        public readonly string Name;
+        public string Name { get; }
 
         public bool Connected { get; private set; } = false;
 

--- a/csharp/ButtplugCSharpFFI/ButtplugClient.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClient.cs
@@ -16,7 +16,7 @@ namespace Buttplug
         /// </summary>
         public string Name { get; }
 
-        public bool Connected { get; private set; } = false;
+        public bool Connected { get; private set; }
 
         private readonly ButtplugFFIMessageSorter _messageSorter = new ButtplugFFIMessageSorter();
 

--- a/csharp/ButtplugCSharpFFI/ButtplugClient.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClient.cs
@@ -8,8 +8,8 @@ namespace Buttplug
 {
     public class ButtplugClient : IDisposable
     {
-        private readonly static Dictionary<uint, WeakReference> _clientStorage = new Dictionary<uint, WeakReference>();
-        private readonly static uint _clientCounter = 1;
+        private static readonly Dictionary<uint, WeakReference> _clientStorage = new Dictionary<uint, WeakReference>();
+        private static readonly uint _clientCounter = 1;
 
         private readonly ButtplugFFIMessageSorter _messageSorter;
         private readonly ButtplugFFIClientHandle _clientHandle;
@@ -128,7 +128,7 @@ namespace Buttplug
             Connected = false;
         }
 
-        static protected void StaticSorterCallback(IntPtr ctx, IntPtr buf, int buf_length)
+        protected static void StaticSorterCallback(IntPtr ctx, IntPtr buf, int buf_length)
         {
             GCHandle indexHandle = GCHandle.FromIntPtr(ctx);
             uint index = (uint)indexHandle.Target;

--- a/csharp/ButtplugCSharpFFI/ButtplugClient.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClient.cs
@@ -105,19 +105,22 @@ namespace Buttplug
                 aConnector.DeviceConfigJSON,
                 aConnector.UserDeviceConfigJSON,
                 aConnector.DeviceCommunicationManagerTypes,
-                SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle));
+                SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+                .ConfigureAwait(false);
             Connected = true;
         }
 
         public async Task ConnectAsync(ButtplugWebsocketConnectorOptions aConnector)
         {
-            await ButtplugFFI.SendConnectWebsocket(_messageSorter, _clientHandle, aConnector.NetworkAddress.ToString(), false, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle));
+            await ButtplugFFI.SendConnectWebsocket(_messageSorter, _clientHandle, aConnector.NetworkAddress.ToString(), false, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+                             .ConfigureAwait(false);
             Connected = true;
         }
 
         public async Task DisconnectAsync()
         {
-            await ButtplugFFI.SendDisconnect(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle));
+            await ButtplugFFI.SendDisconnect(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+                             .ConfigureAwait(false);
             _devices.Clear();
             Connected = false;
         }
@@ -232,22 +235,26 @@ namespace Buttplug
         public async Task StartScanningAsync()
         {
             IsScanning = true;
-            await ButtplugFFI.SendStartScanning(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle));
+            await ButtplugFFI.SendStartScanning(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+                             .ConfigureAwait(false);
         }
 
         public async Task StopScanningAsync()
         {
             IsScanning = false;
-            await ButtplugFFI.SendStopScanning(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle));
+            await ButtplugFFI.SendStopScanning(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+                             .ConfigureAwait(false);
         }
 
         public async Task StopAllDevicesAsync()
         {
-            await ButtplugFFI.SendStopAllDevices(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle));
+            await ButtplugFFI.SendStopAllDevices(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+                             .ConfigureAwait(false);
         }
         public async Task PingAsync()
         {
-            await ButtplugFFI.SendPing(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle));
+            await ButtplugFFI.SendPing(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+                             .ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/csharp/ButtplugCSharpFFI/ButtplugClient.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClient.cs
@@ -53,7 +53,7 @@ namespace Buttplug
         /// Event fired when a server disconnect has occured.
         /// </summary>
         public event EventHandler ServerDisconnect;
-         
+
         public bool IsScanning { get; private set; }
 
         /// <summary>
@@ -107,7 +107,6 @@ namespace Buttplug
                 aConnector.DeviceCommunicationManagerTypes,
                 SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle));
             Connected = true;
-
         }
 
         public async Task ConnectAsync(ButtplugWebsocketConnectorOptions aConnector)
@@ -122,7 +121,7 @@ namespace Buttplug
             _devices.Clear();
             Connected = false;
         }
-        
+
         static protected void StaticSorterCallback(IntPtr ctx, IntPtr buf, int buf_length)
         {
             GCHandle indexHandle = GCHandle.FromIntPtr(ctx);
@@ -137,7 +136,6 @@ namespace Buttplug
 
         protected void SorterCallbackHandler(IntPtr buf, int buf_length)
         {
-            
             // Process the data BEFORE we throw to the C# executor, otherwise
             // Rust will clean up the memory and we'll have nothing to read
             // from, meaning a null message at best and a crash at worst.

--- a/csharp/ButtplugCSharpFFI/ButtplugClient.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,13 +11,13 @@ namespace Buttplug
         private readonly static Dictionary<uint, WeakReference> _clientStorage = new Dictionary<uint, WeakReference>();
         private readonly static uint _clientCounter = 1;
 
-        private readonly ButtplugFFIMessageSorter _messageSorter = new ButtplugFFIMessageSorter();
+        private readonly ButtplugFFIMessageSorter _messageSorter;
         private readonly ButtplugFFIClientHandle _clientHandle;
 
         /// <summary>
         /// Stores information about devices currently connected to the server.
         /// </summary>
-        private readonly Dictionary<uint, ButtplugClientDevice> _devices = new Dictionary<uint, ButtplugClientDevice>();
+        private readonly Dictionary<uint, ButtplugClientDevice> _devices;
         private readonly ButtplugCallback _sorterCallbackDelegate;
 
         // To detect redundant calls
@@ -74,6 +74,9 @@ namespace Buttplug
         {
             Name = aClientName;
             _sorterCallbackDelegate = aCallback;
+
+            _messageSorter = new ButtplugFFIMessageSorter();
+            _devices = new Dictionary<uint, ButtplugClientDevice>();
 
             var context = new WeakReference(this);
             var clientIndex = _clientCounter;

--- a/csharp/ButtplugCSharpFFI/ButtplugClient.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClient.cs
@@ -11,16 +11,31 @@ namespace Buttplug
         private readonly static Dictionary<uint, WeakReference> _clientStorage = new Dictionary<uint, WeakReference>();
         private readonly static uint _clientCounter = 1;
 
+        private readonly ButtplugFFIMessageSorter _messageSorter = new ButtplugFFIMessageSorter();
+
+        private readonly ButtplugFFIClientHandle _clientHandle;
+
+        /// <summary>
+        /// Stores information about devices currently connected to the server.
+        /// </summary>
+        private readonly Dictionary<uint, ButtplugClientDevice> _devices =
+            new Dictionary<uint, ButtplugClientDevice>();
+
+        private readonly ButtplugCallback SorterCallbackDelegate;
+
+        // To detect redundant calls
+        private bool _disposed = false;
+
+        private GCHandle _indexHandle;
+
+        public ButtplugClientDevice[] Devices => _devices.Values.ToArray();
+
         /// <summary>
         /// Name of the client, used for server UI/permissions.
         /// </summary>
         public string Name { get; }
 
         public bool Connected { get; private set; }
-
-        private readonly ButtplugFFIMessageSorter _messageSorter = new ButtplugFFIMessageSorter();
-
-        private readonly ButtplugFFIClientHandle _clientHandle;
 
         /// <summary>
         /// Event fired on Buttplug device added, either after connect or while scanning for devices.
@@ -55,21 +70,6 @@ namespace Buttplug
         public event EventHandler ServerDisconnect;
 
         public bool IsScanning { get; private set; }
-
-        /// <summary>
-        /// Stores information about devices currently connected to the server.
-        /// </summary>
-        private readonly Dictionary<uint, ButtplugClientDevice> _devices =
-            new Dictionary<uint, ButtplugClientDevice>();
-
-        public ButtplugClientDevice[] Devices => _devices.Values.ToArray();
-
-        private readonly ButtplugCallback SorterCallbackDelegate;
-
-        // To detect redundant calls
-        private bool _disposed = false;
-
-        private GCHandle _indexHandle;
 
         public ButtplugClient(string aClientName): this(aClientName, StaticSorterCallback)
         {

--- a/csharp/ButtplugCSharpFFI/ButtplugClient.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClient.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -21,7 +21,7 @@ namespace Buttplug
         private readonly ButtplugCallback _sorterCallbackDelegate;
 
         // To detect redundant calls
-        private bool _disposed = false;
+        private bool _disposed;
         private GCHandle _indexHandle;
 
         public ButtplugClientDevice[] Devices => _devices.Values.ToArray();

--- a/csharp/ButtplugCSharpFFI/ButtplugClient.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClient.cs
@@ -18,7 +18,7 @@ namespace Buttplug
         /// Stores information about devices currently connected to the server.
         /// </summary>
         private readonly Dictionary<uint, ButtplugClientDevice> _devices = new Dictionary<uint, ButtplugClientDevice>();
-        private readonly ButtplugCallback SorterCallbackDelegate;
+        private readonly ButtplugCallback _sorterCallbackDelegate;
 
         // To detect redundant calls
         private bool _disposed = false;
@@ -73,7 +73,7 @@ namespace Buttplug
         protected ButtplugClient(string aClientName, ButtplugCallback aCallback)
         {
             Name = aClientName;
-            SorterCallbackDelegate = aCallback;
+            _sorterCallbackDelegate = aCallback;
 
             var context = new WeakReference(this);
             var clientIndex = _clientCounter;
@@ -81,7 +81,7 @@ namespace Buttplug
             // Since we can pass the handle, I don't *think* this needs to be pinned?
             _indexHandle = GCHandle.Alloc(clientIndex);
             _clientStorage.Add(_clientCounter, context);
-            _clientHandle = ButtplugFFI.SendCreateClient(aClientName, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle));
+            _clientHandle = ButtplugFFI.SendCreateClient(aClientName, _sorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle));
         }
 
         ~ButtplugClient() => Dispose(false);
@@ -102,7 +102,7 @@ namespace Buttplug
                 aConnector.DeviceConfigJSON,
                 aConnector.UserDeviceConfigJSON,
                 aConnector.DeviceCommunicationManagerTypes,
-                SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+                _sorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
                 .ConfigureAwait(false);
 
             Connected = true;
@@ -110,7 +110,7 @@ namespace Buttplug
 
         public async Task ConnectAsync(ButtplugWebsocketConnectorOptions aConnector)
         {
-            await ButtplugFFI.SendConnectWebsocket(_messageSorter, _clientHandle, aConnector.NetworkAddress.ToString(), false, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+            await ButtplugFFI.SendConnectWebsocket(_messageSorter, _clientHandle, aConnector.NetworkAddress.ToString(), false, _sorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
                              .ConfigureAwait(false);
 
             Connected = true;
@@ -118,7 +118,7 @@ namespace Buttplug
 
         public async Task DisconnectAsync()
         {
-            await ButtplugFFI.SendDisconnect(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+            await ButtplugFFI.SendDisconnect(_messageSorter, _clientHandle, _sorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
                              .ConfigureAwait(false);
 
             _devices.Clear();
@@ -179,7 +179,7 @@ namespace Buttplug
                             attribute_dict.Add(attributes.MessageType, device_message_attributes);
                         }
 
-                        var device = new ButtplugClientDevice(_messageSorter, device_handle, device_added_message.Index, device_added_message.Name, attribute_dict, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle));
+                        var device = new ButtplugClientDevice(_messageSorter, device_handle, device_added_message.Index, device_added_message.Name, attribute_dict, _sorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle));
                         _devices.Add(device_added_message.Index, device);
                         DeviceAdded?.Invoke(this, new DeviceAddedEventArgs(device));
                     }
@@ -240,25 +240,25 @@ namespace Buttplug
         public async Task StartScanningAsync()
         {
             IsScanning = true;
-            await ButtplugFFI.SendStartScanning(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+            await ButtplugFFI.SendStartScanning(_messageSorter, _clientHandle, _sorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
                              .ConfigureAwait(false);
         }
 
         public async Task StopScanningAsync()
         {
             IsScanning = false;
-            await ButtplugFFI.SendStopScanning(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+            await ButtplugFFI.SendStopScanning(_messageSorter, _clientHandle, _sorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
                              .ConfigureAwait(false);
         }
 
         public async Task StopAllDevicesAsync()
         {
-            await ButtplugFFI.SendStopAllDevices(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+            await ButtplugFFI.SendStopAllDevices(_messageSorter, _clientHandle, _sorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
                              .ConfigureAwait(false);
         }
         public async Task PingAsync()
         {
-            await ButtplugFFI.SendPing(_messageSorter, _clientHandle, SorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
+            await ButtplugFFI.SendPing(_messageSorter, _clientHandle, _sorterCallbackDelegate, GCHandle.ToIntPtr(_indexHandle))
                              .ConfigureAwait(false);
         }
 

--- a/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
@@ -37,7 +37,7 @@ namespace Buttplug
         /// </summary>
         /// <param name="aIndex">The device index.</param>
         /// <param name="aName">The device name.</param>
-        /// <param name="aMessages">The device allowed message list, with corresponding attributes.</param>
+        /// <param name="aAllowedMessages">The device allowed message list, with corresponding attributes.</param>
         internal ButtplugClientDevice(ButtplugFFIMessageSorter aSorter,
             ButtplugFFIDeviceHandle aHandle,
             uint aIndex,

--- a/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
@@ -7,10 +7,10 @@ namespace Buttplug
 {
     public class ButtplugClientDevice : IDisposable
     {
-        private readonly ButtplugFFIMessageSorter Sorter;
-        private readonly ButtplugFFIDeviceHandle Handle;
-        private readonly ButtplugCallback SorterCallback;
-        private readonly IntPtr SorterCallbackCtx;
+        private readonly ButtplugFFIMessageSorter _sorter;
+        private readonly ButtplugFFIDeviceHandle _handle;
+        private readonly ButtplugCallback _sorterCallback;
+        private readonly IntPtr _sorterCallbackCtx;
 
         /// <summary>
         /// The device index, which uniquely identifies the device on the server.
@@ -46,18 +46,18 @@ namespace Buttplug
             ButtplugCallback aCallback,
             IntPtr aCallbackCtx)
         {
-            Sorter = aSorter;
-            Handle = aHandle;
+            _sorter = aSorter;
+            _handle = aHandle;
             Index = aIndex;
             Name = aName;
             AllowedMessages = aAllowedMessages;
-            SorterCallback = aCallback;
-            SorterCallbackCtx = aCallbackCtx;
+            _sorterCallback = aCallback;
+            _sorterCallbackCtx = aCallbackCtx;
         }
 
         public void Dispose()
         {
-            Handle.Dispose();
+            _handle.Dispose();
         }
 
         public bool Equals(ButtplugClientDevice aDevice)
@@ -91,7 +91,7 @@ namespace Buttplug
 
         public Task SendVibrateCmd(Dictionary<uint, double> aCmds)
         {
-            return ButtplugFFI.SendVibrateCmd(Sorter, Handle, Index, aCmds, SorterCallback, SorterCallbackCtx);
+            return ButtplugFFI.SendVibrateCmd(_sorter, _handle, Index, aCmds, _sorterCallback, _sorterCallbackCtx);
         }
 
         public Task SendRotateCmd(double aSpeed, bool aClockwise)
@@ -120,7 +120,7 @@ namespace Buttplug
 
         public Task SendRotateCmd(Dictionary<uint, (double, bool)> aCmds)
         {
-            return ButtplugFFI.SendRotateCmd(Sorter, Handle, Index, aCmds, SorterCallback, SorterCallbackCtx);
+            return ButtplugFFI.SendRotateCmd(_sorter, _handle, Index, aCmds, _sorterCallback, _sorterCallbackCtx);
         }
 
         public Task SendLinearCmd(uint aDuration, double aPosition)
@@ -149,12 +149,12 @@ namespace Buttplug
 
         public Task SendLinearCmd(Dictionary<uint, (uint, double)> aCmds)
         {
-            return ButtplugFFI.SendLinearCmd(Sorter, Handle, Index, aCmds, SorterCallback, SorterCallbackCtx);
+            return ButtplugFFI.SendLinearCmd(_sorter, _handle, Index, aCmds, _sorterCallback, _sorterCallbackCtx);
         }
 
         public async Task<double> SendBatteryLevelCmd()
         {
-            var reading = await ButtplugFFI.SendBatteryLevelCmd(Sorter, Handle, Index, SorterCallback, SorterCallbackCtx)
+            var reading = await ButtplugFFI.SendBatteryLevelCmd(_sorter, _handle, Index, _sorterCallback, _sorterCallbackCtx)
                                            .ConfigureAwait(false);
 
             if (reading.Message.MsgCase == ButtplugFFIServerMessage.Types.FFIMessage.MsgOneofCase.DeviceEvent
@@ -168,7 +168,7 @@ namespace Buttplug
 
         public async Task<int> SendRSSIBatteryLevelCmd()
         {
-            var reading = await ButtplugFFI.SendRSSILevelCmd(Sorter, Handle, Index, SorterCallback, SorterCallbackCtx)
+            var reading = await ButtplugFFI.SendRSSILevelCmd(_sorter, _handle, Index, _sorterCallback, _sorterCallbackCtx)
                                            .ConfigureAwait(false);
 
             if (reading.Message.MsgCase == ButtplugFFIServerMessage.Types.FFIMessage.MsgOneofCase.DeviceEvent
@@ -182,7 +182,7 @@ namespace Buttplug
 
         public async Task<byte[]> SendRawReadCmd(Endpoint aEndpoint, uint aExpectedLength, uint aTimeout)
         {
-            var reading = await ButtplugFFI.SendRawReadCmd(Sorter, Handle, Index, aEndpoint, aExpectedLength, aTimeout, SorterCallback, SorterCallbackCtx)
+            var reading = await ButtplugFFI.SendRawReadCmd(_sorter, _handle, Index, aEndpoint, aExpectedLength, aTimeout, _sorterCallback, _sorterCallbackCtx)
                                            .ConfigureAwait(false);
 
             if (reading.Message.MsgCase == ButtplugFFIServerMessage.Types.FFIMessage.MsgOneofCase.DeviceEvent
@@ -196,23 +196,23 @@ namespace Buttplug
 
         public Task SendRawWriteCmd(Endpoint aEndpoint, byte[] aData, bool aWriteWithResponse)
         {
-            return ButtplugFFI.SendRawWriteCmd(Sorter, Handle, Index, aEndpoint, aData, aWriteWithResponse, SorterCallback, SorterCallbackCtx);
+            return ButtplugFFI.SendRawWriteCmd(_sorter, _handle, Index, aEndpoint, aData, aWriteWithResponse, _sorterCallback, _sorterCallbackCtx);
         }
 
         public Task SendRawSubscribeCmd(Endpoint aEndpoint)
         {
-            return ButtplugFFI.SendRawSubscribeCmd(Sorter, Handle, Index, aEndpoint, SorterCallback, SorterCallbackCtx);
+            return ButtplugFFI.SendRawSubscribeCmd(_sorter, _handle, Index, aEndpoint, _sorterCallback, _sorterCallbackCtx);
         }
 
         public Task SendRawUnsubscribeCmd(Endpoint aEndpoint)
         {
-            return ButtplugFFI.SendRawUnsubscribeCmd(Sorter, Handle, Index, aEndpoint, SorterCallback, SorterCallbackCtx);
+            return ButtplugFFI.SendRawUnsubscribeCmd(_sorter, _handle, Index, aEndpoint, _sorterCallback, _sorterCallbackCtx);
         }
 
         public Task SendStopDeviceCmd()
         {
             // Every message should support this, but it doesn't hurt to check
-            return ButtplugFFI.SendStopDeviceCmd(Sorter, Handle, Index, SorterCallback, SorterCallbackCtx);
+            return ButtplugFFI.SendStopDeviceCmd(_sorter, _handle, Index, _sorterCallback, _sorterCallbackCtx);
         }
     }
 }

--- a/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
@@ -199,6 +199,5 @@ namespace Buttplug
             // Every message should support this, but it doesn't hurt to check
             return ButtplugFFI.SendStopDeviceCmd(Sorter, Handle, Index, SorterCallback, SorterCallbackCtx);
         }
-
     }
 }

--- a/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
@@ -14,12 +14,12 @@ namespace Buttplug
         /// If a device is removed, this may be the only populated field. If the same device
         /// reconnects, the index should be reused.
         /// </remarks>
-        public readonly uint Index;
+        public uint Index { get; }
 
         /// <summary>
         /// The device name, which usually contains the device brand and model.
         /// </summary>
-        public readonly string Name;
+        public string Name { get; }
 
         /// <summary>
         /// The Buttplug Protocol messages supported by this device, with additional attributes.

--- a/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
@@ -26,12 +26,12 @@ namespace Buttplug
         /// </summary>
         public Dictionary<ServerMessage.Types.MessageAttributeType, ButtplugMessageAttributes> AllowedMessages { get; }
 
-        private ButtplugFFIMessageSorter Sorter;
+        private readonly ButtplugFFIMessageSorter Sorter;
 
-        private ButtplugFFIDeviceHandle Handle;
+        private readonly ButtplugFFIDeviceHandle Handle;
 
-        private ButtplugCallback SorterCallback;
-        private IntPtr SorterCallbackCtx;
+        private readonly ButtplugCallback SorterCallback;
+        private readonly IntPtr SorterCallbackCtx;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ButtplugClientDevice"/> class, using

--- a/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
@@ -8,9 +8,7 @@ namespace Buttplug
     public class ButtplugClientDevice : IDisposable
     {
         private readonly ButtplugFFIMessageSorter Sorter;
-
         private readonly ButtplugFFIDeviceHandle Handle;
-
         private readonly ButtplugCallback SorterCallback;
         private readonly IntPtr SorterCallbackCtx;
 
@@ -75,6 +73,7 @@ namespace Buttplug
             {
                 count = AllowedMessages[ServerMessage.Types.MessageAttributeType.VibrateCmd].FeatureCount;
             }
+
             // There is probably a cleaner, LINQyer way to do this but ugh don't care.
             var commandDict = new Dictionary<uint, double>();
             for (var i = 0u; i < count; ++i)
@@ -103,12 +102,14 @@ namespace Buttplug
             {
                 count = AllowedMessages[ServerMessage.Types.MessageAttributeType.RotateCmd].FeatureCount;
             }
+
             // There is probably a cleaner, LINQyer way to do this but ugh don't care.
             var commandDict = new Dictionary<uint, (double, bool)>();
             for (var i = 0u; i < count; ++i)
             {
                 commandDict.Add(i, (aSpeed, aClockwise));
             }
+
             return SendRotateCmd(commandDict);
         }
 
@@ -130,12 +131,14 @@ namespace Buttplug
             {
                 count = AllowedMessages[ServerMessage.Types.MessageAttributeType.LinearCmd].FeatureCount;
             }
+
             // There is probably a cleaner, LINQyer way to do this but ugh don't care.
             var commandDict = new Dictionary<uint, (uint, double)>();
             for (var i = 0u; i < count; ++i)
             {
                 commandDict.Add(i, (aDuration, aPosition));
             }
+
             return SendLinearCmd(commandDict);
         }
 
@@ -153,10 +156,13 @@ namespace Buttplug
         {
             var reading = await ButtplugFFI.SendBatteryLevelCmd(Sorter, Handle, Index, SorterCallback, SorterCallbackCtx)
                                            .ConfigureAwait(false);
-            if (reading.Message.MsgCase == ButtplugFFIServerMessage.Types.FFIMessage.MsgOneofCase.DeviceEvent && reading.Message.DeviceEvent.MsgCase == DeviceEvent.MsgOneofCase.BatteryLevelReading)
+
+            if (reading.Message.MsgCase == ButtplugFFIServerMessage.Types.FFIMessage.MsgOneofCase.DeviceEvent
+             && reading.Message.DeviceEvent.MsgCase == DeviceEvent.MsgOneofCase.BatteryLevelReading)
             {
                 return reading.Message.DeviceEvent.BatteryLevelReading.Reading;
             }
+
             throw new ButtplugDeviceException($"Expected message type of BatteryLevelReading not received, got {reading.Message.MsgCase} instead.");
         }
 
@@ -164,10 +170,13 @@ namespace Buttplug
         {
             var reading = await ButtplugFFI.SendRSSILevelCmd(Sorter, Handle, Index, SorterCallback, SorterCallbackCtx)
                                            .ConfigureAwait(false);
-            if (reading.Message.MsgCase == ButtplugFFIServerMessage.Types.FFIMessage.MsgOneofCase.DeviceEvent && reading.Message.DeviceEvent.MsgCase == DeviceEvent.MsgOneofCase.RssiLevelReading)
+
+            if (reading.Message.MsgCase == ButtplugFFIServerMessage.Types.FFIMessage.MsgOneofCase.DeviceEvent
+             && reading.Message.DeviceEvent.MsgCase == DeviceEvent.MsgOneofCase.RssiLevelReading)
             {
                 return reading.Message.DeviceEvent.RssiLevelReading.Reading;
             }
+
             throw new ButtplugDeviceException($"Expected message type of RssiLevelReading not received, got {reading.Message.MsgCase} instead.");
         }
 
@@ -175,10 +184,13 @@ namespace Buttplug
         {
             var reading = await ButtplugFFI.SendRawReadCmd(Sorter, Handle, Index, aEndpoint, aExpectedLength, aTimeout, SorterCallback, SorterCallbackCtx)
                                            .ConfigureAwait(false);
-            if (reading.Message.MsgCase == ButtplugFFIServerMessage.Types.FFIMessage.MsgOneofCase.DeviceEvent && reading.Message.DeviceEvent.MsgCase == DeviceEvent.MsgOneofCase.RawReading)
+
+            if (reading.Message.MsgCase == ButtplugFFIServerMessage.Types.FFIMessage.MsgOneofCase.DeviceEvent
+             && reading.Message.DeviceEvent.MsgCase == DeviceEvent.MsgOneofCase.RawReading)
             {
                 return reading.Message.DeviceEvent.RawReading.Data.ToArray();
             }
+
             throw new ButtplugDeviceException($"Expected message type of RssiLevelReading not received, got {reading.Message.MsgCase} instead.");
         }
 

--- a/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
@@ -151,7 +151,8 @@ namespace Buttplug
 
         public async Task<double> SendBatteryLevelCmd()
         {
-            var reading = await ButtplugFFI.SendBatteryLevelCmd(Sorter, Handle, Index, SorterCallback, SorterCallbackCtx);
+            var reading = await ButtplugFFI.SendBatteryLevelCmd(Sorter, Handle, Index, SorterCallback, SorterCallbackCtx)
+                                           .ConfigureAwait(false);
             if (reading.Message.MsgCase == ButtplugFFIServerMessage.Types.FFIMessage.MsgOneofCase.DeviceEvent && reading.Message.DeviceEvent.MsgCase == DeviceEvent.MsgOneofCase.BatteryLevelReading)
             {
                 return reading.Message.DeviceEvent.BatteryLevelReading.Reading;
@@ -161,7 +162,8 @@ namespace Buttplug
 
         public async Task<int> SendRSSIBatteryLevelCmd()
         {
-            var reading = await ButtplugFFI.SendRSSILevelCmd(Sorter, Handle, Index, SorterCallback, SorterCallbackCtx);
+            var reading = await ButtplugFFI.SendRSSILevelCmd(Sorter, Handle, Index, SorterCallback, SorterCallbackCtx)
+                                           .ConfigureAwait(false);
             if (reading.Message.MsgCase == ButtplugFFIServerMessage.Types.FFIMessage.MsgOneofCase.DeviceEvent && reading.Message.DeviceEvent.MsgCase == DeviceEvent.MsgOneofCase.RssiLevelReading)
             {
                 return reading.Message.DeviceEvent.RssiLevelReading.Reading;
@@ -171,7 +173,8 @@ namespace Buttplug
 
         public async Task<byte[]> SendRawReadCmd(Endpoint aEndpoint, uint aExpectedLength, uint aTimeout)
         {
-            var reading = await ButtplugFFI.SendRawReadCmd(Sorter, Handle, Index, aEndpoint, aExpectedLength, aTimeout, SorterCallback, SorterCallbackCtx);
+            var reading = await ButtplugFFI.SendRawReadCmd(Sorter, Handle, Index, aEndpoint, aExpectedLength, aTimeout, SorterCallback, SorterCallbackCtx)
+                                           .ConfigureAwait(false);
             if (reading.Message.MsgCase == ButtplugFFIServerMessage.Types.FFIMessage.MsgOneofCase.DeviceEvent && reading.Message.DeviceEvent.MsgCase == DeviceEvent.MsgOneofCase.RawReading)
             {
                 return reading.Message.DeviceEvent.RawReading.Data.ToArray();

--- a/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugClientDevice.cs
@@ -7,6 +7,13 @@ namespace Buttplug
 {
     public class ButtplugClientDevice : IDisposable
     {
+        private readonly ButtplugFFIMessageSorter Sorter;
+
+        private readonly ButtplugFFIDeviceHandle Handle;
+
+        private readonly ButtplugCallback SorterCallback;
+        private readonly IntPtr SorterCallbackCtx;
+
         /// <summary>
         /// The device index, which uniquely identifies the device on the server.
         /// </summary>
@@ -25,13 +32,6 @@ namespace Buttplug
         /// The Buttplug Protocol messages supported by this device, with additional attributes.
         /// </summary>
         public Dictionary<ServerMessage.Types.MessageAttributeType, ButtplugMessageAttributes> AllowedMessages { get; }
-
-        private readonly ButtplugFFIMessageSorter Sorter;
-
-        private readonly ButtplugFFIDeviceHandle Handle;
-
-        private readonly ButtplugCallback SorterCallback;
-        private readonly IntPtr SorterCallbackCtx;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ButtplugClientDevice"/> class, using

--- a/csharp/ButtplugCSharpFFI/ButtplugConnectorException.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugConnectorException.cs
@@ -5,8 +5,17 @@ namespace Buttplug
     public class ButtplugConnectorException : ButtplugException
     {
         /// <inheritdoc />
-        public ButtplugConnectorException(string aMessage, Exception aInner = null)
-            : base(aMessage, aInner)
+        public ButtplugConnectorException()
+        {
+        }
+
+        /// <inheritdoc />
+        public ButtplugConnectorException(string aMessage) : base(aMessage)
+        {
+        }
+
+        /// <inheritdoc />
+        public ButtplugConnectorException(string aMessage, Exception aInner) : base(aMessage, aInner)
         {
         }
     }

--- a/csharp/ButtplugCSharpFFI/ButtplugDeviceException.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugDeviceException.cs
@@ -5,8 +5,17 @@ namespace Buttplug
     public class ButtplugDeviceException : ButtplugException
     {
         /// <inheritdoc />
-        public ButtplugDeviceException(string aMessage, Exception aInner = null)
-            : base(aMessage, aInner)
+        public ButtplugDeviceException()
+        {
+        }
+
+        /// <inheritdoc />
+        public ButtplugDeviceException(string aMessage) : base(aMessage)
+        {
+        }
+
+        /// <inheritdoc />
+        public ButtplugDeviceException(string aMessage, Exception aInner) : base(aMessage, aInner)
         {
         }
     }

--- a/csharp/ButtplugCSharpFFI/ButtplugEmbeddedConnectorOptions.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugEmbeddedConnectorOptions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Buttplug
+﻿namespace Buttplug
 {
     public class ButtplugEmbeddedConnectorOptions
     {

--- a/csharp/ButtplugCSharpFFI/ButtplugEmbeddedConnectorOptions.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugEmbeddedConnectorOptions.cs
@@ -16,9 +16,5 @@ namespace Buttplug
         // Always opt-in on raw messages.
         public bool AllowRawMessages { get; set; } = false;
         public uint MaxPingTime { get; set; } = 0;
-
-        public ButtplugEmbeddedConnectorOptions()
-        {
-        }
     }
 }

--- a/csharp/ButtplugCSharpFFI/ButtplugEmbeddedConnectorOptions.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugEmbeddedConnectorOptions.cs
@@ -6,16 +6,16 @@ namespace Buttplug
 {
     public class ButtplugEmbeddedConnectorOptions
     {
-        public string ServerName = "Buttplug C# Embedded Server";
+        public string ServerName { get; set; } = "Buttplug C# Embedded Server";
         // Empty string means ignore.
-        public string DeviceConfigJSON = "";
+        public string DeviceConfigJSON { get; set; } = "";
         // Empty string means ignore.
-        public string UserDeviceConfigJSON = "";
+        public string UserDeviceConfigJSON { get; set; } = "";
         // 0 here means all device.
-        public ushort DeviceCommunicationManagerTypes = 0;
+        public ushort DeviceCommunicationManagerTypes { get; set; } = 0;
         // Always opt-in on raw messages.
-        public bool AllowRawMessages = false;
-        public uint MaxPingTime = 0;
+        public bool AllowRawMessages { get; set; } = false;
+        public uint MaxPingTime { get; set; } = 0;
 
         public ButtplugEmbeddedConnectorOptions()
         {

--- a/csharp/ButtplugCSharpFFI/ButtplugException.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugException.cs
@@ -50,6 +50,7 @@ namespace Buttplug
                 case ServerMessage.Types.ButtplugErrorType.ButtplugDeviceError:
                     return new ButtplugDeviceException(err_str);
             }
+
             return new ButtplugUnknownException($"Unknown error type: {aMsg.ErrorType} | Message: {aMsg.Message}");
         }
     }

--- a/csharp/ButtplugCSharpFFI/ButtplugException.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugException.cs
@@ -8,11 +8,27 @@ namespace Buttplug
         /// <summary>
         /// Creates a ButtplugException.
         /// </summary>
+        public ButtplugException()
+        {
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// Creates a ButtplugException.
+        /// </summary>
+        /// <param name="aMessage">Exception message.</param>
+        public ButtplugException(string aMessage) : base(aMessage)
+        {
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// Creates a ButtplugException.
+        /// </summary>
         /// <param name="aMessage">Exception message.</param>
         /// <param name="aClass">Exception class, based on Buttplug Error Message Classes. (https://buttplug-spec.docs.buttplug.io/status.html#error).</param>
-        /// <param name="aInner">Optional inner exception.</param>
-        public ButtplugException(string aMessage, Exception aInner = null)
-            : base(aMessage, aInner)
+        /// <param name="aInner">Inner exception.</param>
+        public ButtplugException(string aMessage, Exception aInner) : base(aMessage, aInner)
         {
         }
 

--- a/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
@@ -49,7 +49,7 @@ namespace Buttplug
 
     }
 
-    internal class ButtplugFFICalls
+    internal static class ButtplugFFICalls
     {
         [DllImport("buttplug_rs_ffi")]
         internal static extern ButtplugFFIClientHandle buttplug_create_protobuf_client(string client_name, ButtplugCallback callback, IntPtr ctx);
@@ -73,7 +73,7 @@ namespace Buttplug
         internal static extern void buttplug_activate_env_logger();
     }
 
-    internal class ButtplugFFI
+    internal static class ButtplugFFI
     {
         internal static ButtplugFFIClientHandle SendCreateClient(string aClientName, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {

--- a/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
@@ -3,46 +3,31 @@ using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using Google.Protobuf;
+using Microsoft.Win32.SafeHandles;
 
 namespace Buttplug
 {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void ButtplugCallback(IntPtr ctx, IntPtr buf, int buf_length);
 
-    internal class ButtplugFFIClientHandle : SafeHandle
+    internal class ButtplugFFIClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        public ButtplugFFIClientHandle() : base(IntPtr.Zero, true) { }
-
-        public override bool IsInvalid
-        {
-            get { return this.handle == IntPtr.Zero; }
-        }
+        public ButtplugFFIClientHandle() : base(true) { }
 
         protected override bool ReleaseHandle()
         {
-            if (!this.IsInvalid)
-            {
-                ButtplugFFICalls.ButtplugFreeClient(handle);
-            }
+            ButtplugFFICalls.ButtplugFreeClient(handle);
             return true;
         }
     }
 
-    internal class ButtplugFFIDeviceHandle : SafeHandle
+    internal class ButtplugFFIDeviceHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        public ButtplugFFIDeviceHandle() : base(IntPtr.Zero, true) { }
-
-        public override bool IsInvalid
-        {
-            get { return this.handle == IntPtr.Zero; }
-        }
+        public ButtplugFFIDeviceHandle() : base(true) { }
 
         protected override bool ReleaseHandle()
         {
-            if (!this.IsInvalid)
-            {
-                ButtplugFFICalls.ButtplugFreeDevice(handle);
-            }
+            ButtplugFFICalls.ButtplugFreeDevice(handle);
             return true;
         }
     }

--- a/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
@@ -26,7 +26,6 @@ namespace Buttplug
             }
             return true;
         }
-
     }
 
     internal class ButtplugFFIDeviceHandle : SafeHandle
@@ -46,7 +45,6 @@ namespace Buttplug
             }
             return true;
         }
-
     }
 
     internal static class ButtplugFFICalls
@@ -89,7 +87,7 @@ namespace Buttplug
         }
 
         internal static Task<ButtplugFFIServerMessage> SendConnectLocal(
-            ButtplugFFIMessageSorter aSorter, 
+            ButtplugFFIMessageSorter aSorter,
             ButtplugFFIClientHandle aHandle,
             string aServerName,
             uint aMaxPingTime,
@@ -97,7 +95,7 @@ namespace Buttplug
             string aDeviceConfigJSON,
             string aUserDeviceConfigJSON,
             ushort aDeviceCommManagerTypes,
-            ButtplugCallback aCallback, 
+            ButtplugCallback aCallback,
             IntPtr aCallbackCtx)
         {
             var msg = new ClientMessage();
@@ -193,7 +191,7 @@ namespace Buttplug
             var command_list = new List<DeviceMessage.Types.VibrateComponent>();
             foreach (var pair in aSpeeds)
             {
-                command_list.Add(new DeviceMessage.Types.VibrateComponent { 
+                command_list.Add(new DeviceMessage.Types.VibrateComponent {
                     Index = pair.Key,
                     Speed = pair.Value,
                 });

--- a/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
@@ -136,9 +136,7 @@ namespace Buttplug
         {
             var msg = new ClientMessage();
             msg.Message = new ClientMessage.Types.FFIMessage();
-            msg.Message.StartScanning = new ClientMessage.Types.StartScanning
-            {
-            };
+            msg.Message.StartScanning = new ClientMessage.Types.StartScanning();
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -146,9 +144,7 @@ namespace Buttplug
         {
             var msg = new ClientMessage();
             msg.Message = new ClientMessage.Types.FFIMessage();
-            msg.Message.StopScanning = new ClientMessage.Types.StopScanning
-            {
-            };
+            msg.Message.StopScanning = new ClientMessage.Types.StopScanning();
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -156,18 +152,14 @@ namespace Buttplug
         {
             var msg = new ClientMessage();
             msg.Message = new ClientMessage.Types.FFIMessage();
-            msg.Message.StopAllDevices = new ClientMessage.Types.StopAllDevices
-            {
-            };
+            msg.Message.StopAllDevices = new ClientMessage.Types.StopAllDevices();
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
         internal static Task<ButtplugFFIServerMessage> SendPing(ButtplugFFIMessageSorter aSorter, ButtplugFFIClientHandle aHandle, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
             var msg = new ClientMessage();
             msg.Message = new ClientMessage.Types.FFIMessage();
-            msg.Message.Ping = new ClientMessage.Types.Ping
-            {
-            };
+            msg.Message.Ping = new ClientMessage.Types.Ping();
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 

--- a/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
@@ -340,16 +340,17 @@ namespace Buttplug
         {
             var msg = new DeviceMessage
             {
-                Message = new DeviceMessage.Types.FFIMessage(),
-                Index = aDeviceIndex
+                Index = aDeviceIndex,
+                Message = new DeviceMessage.Types.FFIMessage
+                {
+                    RawReadCmd = new DeviceMessage.Types.RawReadCmd
+                    {
+                        Endpoint = aEndpoint,
+                        ExpectedLength = aLength,
+                        Timeout = aTimeout
+                    }
+                }
             };
-            var cmd = new DeviceMessage.Types.RawReadCmd {
-                Endpoint = aEndpoint,
-                ExpectedLength = aLength,
-                Timeout = aTimeout
-            };
-            msg.Message.RawReadCmd = cmd;
-
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -357,16 +358,17 @@ namespace Buttplug
         {
             var msg = new DeviceMessage
             {
-                Message = new DeviceMessage.Types.FFIMessage(),
-                Index = aDeviceIndex
+                Index = aDeviceIndex,
+                Message = new DeviceMessage.Types.FFIMessage
+                {
+                    RawWriteCmd = new DeviceMessage.Types.RawWriteCmd
+                    {
+                        Endpoint = aEndpoint,
+                        Data = ByteString.CopyFrom(aData),
+                        WriteWithResponse = aWriteWithResponse
+                    }
+                }
             };
-            var cmd = new DeviceMessage.Types.RawWriteCmd
-            {
-                Endpoint = aEndpoint,
-                Data = ByteString.CopyFrom(aData),
-                WriteWithResponse = aWriteWithResponse
-            };
-            msg.Message.RawWriteCmd = cmd;
 
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
@@ -375,14 +377,15 @@ namespace Buttplug
         {
             var msg = new DeviceMessage
             {
-                Message = new DeviceMessage.Types.FFIMessage(),
-                Index = aDeviceIndex
+                Index = aDeviceIndex,
+                Message = new DeviceMessage.Types.FFIMessage
+                {
+                    RawSubscribeCmd = new DeviceMessage.Types.RawSubscribeCmd
+                    {
+                        Endpoint = aEndpoint,
+                    }
+                }
             };
-            var cmd = new DeviceMessage.Types.RawSubscribeCmd
-            {
-                Endpoint = aEndpoint,
-            };
-            msg.Message.RawSubscribeCmd = cmd;
 
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
@@ -391,14 +394,15 @@ namespace Buttplug
         {
             var msg = new DeviceMessage
             {
-                Message = new DeviceMessage.Types.FFIMessage(),
-                Index = aDeviceIndex
+                Index = aDeviceIndex,
+                Message = new DeviceMessage.Types.FFIMessage
+                {
+                    RawUnsubscribeCmd = new DeviceMessage.Types.RawUnsubscribeCmd
+                    {
+                        Endpoint = aEndpoint,
+                    }
+                }
             };
-            var cmd = new DeviceMessage.Types.RawUnsubscribeCmd
-            {
-                Endpoint = aEndpoint,
-            };
-            msg.Message.RawUnsubscribeCmd = cmd;
 
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }

--- a/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
@@ -113,6 +113,7 @@ namespace Buttplug
                     }
                 }
             };
+
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -129,6 +130,7 @@ namespace Buttplug
                     }
                 }
             };
+
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -141,6 +143,7 @@ namespace Buttplug
                     Disconnect = new ClientMessage.Types.Disconnect()
                 }
             };
+
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -153,6 +156,7 @@ namespace Buttplug
                     StartScanning = new ClientMessage.Types.StartScanning()
                 }
             };
+
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -165,6 +169,7 @@ namespace Buttplug
                     StopScanning = new ClientMessage.Types.StopScanning()
                 }
             };
+
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -177,6 +182,7 @@ namespace Buttplug
                     StopAllDevices = new ClientMessage.Types.StopAllDevices()
                 }
             };
+
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
         internal static Task<ButtplugFFIServerMessage> SendPing(ButtplugFFIMessageSorter aSorter, ButtplugFFIClientHandle aHandle, ButtplugCallback aCallback, IntPtr aCallbackCtx)
@@ -188,6 +194,7 @@ namespace Buttplug
                     Ping = new ClientMessage.Types.Ping()
                 }
             };
+
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -215,6 +222,7 @@ namespace Buttplug
                     Speed = pair.Value,
                 });
             }
+
             var cmd = new DeviceMessage.Types.VibrateCmd();
             cmd.Speeds.Add(command_list);
 
@@ -226,6 +234,7 @@ namespace Buttplug
                     VibrateCmd = cmd
                 }
             };
+
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -241,6 +250,7 @@ namespace Buttplug
                     Clockwise = pair.Value.Item2,
                 });
             }
+
             var cmd = new DeviceMessage.Types.RotateCmd();
             cmd.Rotations.Add(command_list);
 
@@ -252,6 +262,7 @@ namespace Buttplug
                     RotateCmd = cmd
                 }
             };
+
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -267,6 +278,7 @@ namespace Buttplug
                     Position = pair.Value.Item2,
                 });
             }
+
             var cmd = new DeviceMessage.Types.LinearCmd();
             cmd.Movements.Add(command_list);
 
@@ -278,6 +290,7 @@ namespace Buttplug
                     LinearCmd = cmd
                 }
             };
+
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -291,6 +304,7 @@ namespace Buttplug
                     StopDeviceCmd = new DeviceMessage.Types.StopDeviceCmd()
                 }
             };
+
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -304,6 +318,7 @@ namespace Buttplug
                     BatteryLevelCmd = new DeviceMessage.Types.BatteryLevelCmd()
                 }
             };
+
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -317,6 +332,7 @@ namespace Buttplug
                     RssiLevelCmd = new DeviceMessage.Types.RSSILevelCmd()
                 }
             };
+
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -333,6 +349,7 @@ namespace Buttplug
                 Timeout = aTimeout
             };
             msg.Message.RawReadCmd = cmd;
+
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -350,6 +367,7 @@ namespace Buttplug
                 WriteWithResponse = aWriteWithResponse
             };
             msg.Message.RawWriteCmd = cmd;
+
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -365,6 +383,7 @@ namespace Buttplug
                 Endpoint = aEndpoint,
             };
             msg.Message.RawSubscribeCmd = cmd;
+
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -380,6 +399,7 @@ namespace Buttplug
                 Endpoint = aEndpoint,
             };
             msg.Message.RawUnsubscribeCmd = cmd;
+
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 

--- a/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
@@ -22,7 +22,7 @@ namespace Buttplug
         {
             if (!this.IsInvalid)
             {
-                ButtplugFFICalls.buttplug_free_client(handle);
+                ButtplugFFICalls.ButtplugFreeClient(handle);
             }
             return true;
         }
@@ -41,7 +41,7 @@ namespace Buttplug
         {
             if (!this.IsInvalid)
             {
-                ButtplugFFICalls.buttplug_free_device(handle);
+                ButtplugFFICalls.ButtplugFreeDevice(handle);
             }
             return true;
         }
@@ -49,40 +49,40 @@ namespace Buttplug
 
     internal static class ButtplugFFICalls
     {
-        [DllImport("buttplug_rs_ffi")]
-        internal static extern ButtplugFFIClientHandle buttplug_create_protobuf_client(string client_name, ButtplugCallback callback, IntPtr ctx);
+        [DllImport("buttplug_rs_ffi", EntryPoint = "buttplug_create_protobuf_client")]
+        internal static extern ButtplugFFIClientHandle ButtplugCreateProtobufClient(string client_name, ButtplugCallback callback, IntPtr ctx);
 
-        [DllImport("buttplug_rs_ffi")]
-        internal static extern void buttplug_free_client(IntPtr client_handle);
+        [DllImport("buttplug_rs_ffi", EntryPoint = "buttplug_free_client")]
+        internal static extern void ButtplugFreeClient(IntPtr client_handle);
 
-        [DllImport("buttplug_rs_ffi")]
-        internal static extern void buttplug_client_protobuf_message(ButtplugFFIClientHandle client_handle, byte[] buf, int buf_length, ButtplugCallback callback, IntPtr ctx);
+        [DllImport("buttplug_rs_ffi", EntryPoint = "buttplug_client_protobuf_message")]
+        internal static extern void ButtplugClientProtobufMessage(ButtplugFFIClientHandle client_handle, byte[] buf, int buf_length, ButtplugCallback callback, IntPtr ctx);
 
-        [DllImport("buttplug_rs_ffi")]
-        internal static extern ButtplugFFIDeviceHandle buttplug_create_device(ButtplugFFIClientHandle client_handle, uint device_index);
+        [DllImport("buttplug_rs_ffi", EntryPoint = "buttplug_create_device")]
+        internal static extern ButtplugFFIDeviceHandle ButtplugCreateDevice(ButtplugFFIClientHandle client_handle, uint device_index);
 
-        [DllImport("buttplug_rs_ffi")]
-        internal static extern void buttplug_device_protobuf_message(ButtplugFFIDeviceHandle client_handle, byte[] buf, int buf_length, ButtplugCallback callback, IntPtr ctx);
+        [DllImport("buttplug_rs_ffi", EntryPoint = "buttplug_device_protobuf_message")]
+        internal static extern void ButtplugDeviceProtobufMessage(ButtplugFFIDeviceHandle client_handle, byte[] buf, int buf_length, ButtplugCallback callback, IntPtr ctx);
 
-        [DllImport("buttplug_rs_ffi")]
-        internal static extern void buttplug_free_device(IntPtr device_handle);
+        [DllImport("buttplug_rs_ffi", EntryPoint = "buttplug_free_device")]
+        internal static extern void ButtplugFreeDevice(IntPtr device_handle);
 
-        [DllImport("buttplug_rs_ffi")]
-        internal static extern void buttplug_activate_env_logger();
+        [DllImport("buttplug_rs_ffi", EntryPoint = "buttplug_activate_env_logger")]
+        internal static extern void ButtplugActivateEnvLogger();
     }
 
     internal static class ButtplugFFI
     {
         internal static ButtplugFFIClientHandle SendCreateClient(string aClientName, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            return ButtplugFFICalls.buttplug_create_protobuf_client(aClientName, aCallback, aCallbackCtx);
+            return ButtplugFFICalls.ButtplugCreateProtobufClient(aClientName, aCallback, aCallbackCtx);
         }
 
         internal static Task<ButtplugFFIServerMessage> SendClientMessage(ButtplugFFIMessageSorter aSorter, ButtplugFFIClientHandle aHandle, ClientMessage aMsg, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
             var task = aSorter.PrepareClientMessage(aMsg);
             var buf = aMsg.ToByteArray();
-            ButtplugFFICalls.buttplug_client_protobuf_message(aHandle, buf, buf.Length, aCallback, aCallbackCtx);
+            ButtplugFFICalls.ButtplugClientProtobufMessage(aHandle, buf, buf.Length, aCallback, aCallbackCtx);
             return task;
         }
 
@@ -193,14 +193,14 @@ namespace Buttplug
 
         internal static ButtplugFFIDeviceHandle SendCreateDevice(ButtplugFFIClientHandle aHandle, uint aDeviceIndex)
         {
-            return ButtplugFFICalls.buttplug_create_device(aHandle, aDeviceIndex);
+            return ButtplugFFICalls.ButtplugCreateDevice(aHandle, aDeviceIndex);
         }
 
         internal static Task<ButtplugFFIServerMessage> SendDeviceMessage(ButtplugFFIMessageSorter aSorter, ButtplugFFIDeviceHandle aHandle, DeviceMessage aMsg, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
             var task = aSorter.PrepareDeviceMessage(aMsg);
             var buf = aMsg.ToByteArray();
-            ButtplugFFICalls.buttplug_device_protobuf_message(aHandle, buf, buf.Length, aCallback, aCallbackCtx);
+            ButtplugFFICalls.ButtplugDeviceProtobufMessage(aHandle, buf, buf.Length, aCallback, aCallbackCtx);
             return task;
         }
 
@@ -385,7 +385,7 @@ namespace Buttplug
 
         internal static void ActivateEnvLogger()
         {
-            ButtplugFFICalls.buttplug_activate_env_logger();
+            ButtplugFFICalls.ButtplugActivateEnvLogger();
         }
     }
 }

--- a/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFI.cs
@@ -98,68 +98,96 @@ namespace Buttplug
             ButtplugCallback aCallback,
             IntPtr aCallbackCtx)
         {
-            var msg = new ClientMessage();
-            msg.Message = new ClientMessage.Types.FFIMessage();
-            msg.Message.ConnectLocal = new ClientMessage.Types.ConnectLocal
+            var msg = new ClientMessage
             {
-                ServerName = aServerName,
-                MaxPingTime = aMaxPingTime,
-                AllowRawMessages = aAllowRawMessages,
-                DeviceConfigurationJson = aDeviceConfigJSON ?? "",
-                UserDeviceConfigurationJson = aUserDeviceConfigJSON ?? "",
-                CommManagerTypes = aDeviceCommManagerTypes
+                Message = new ClientMessage.Types.FFIMessage
+                {
+                    ConnectLocal = new ClientMessage.Types.ConnectLocal
+                    {
+                        ServerName = aServerName,
+                        MaxPingTime = aMaxPingTime,
+                        AllowRawMessages = aAllowRawMessages,
+                        DeviceConfigurationJson = aDeviceConfigJSON ?? "",
+                        UserDeviceConfigurationJson = aUserDeviceConfigJSON ?? "",
+                        CommManagerTypes = aDeviceCommManagerTypes
+                    }
+                }
             };
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
         internal static Task<ButtplugFFIServerMessage> SendConnectWebsocket(ButtplugFFIMessageSorter aSorter, ButtplugFFIClientHandle aHandle, string aAddress, bool aIgnoreCert, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            var msg = new ClientMessage();
-            msg.Message = new ClientMessage.Types.FFIMessage();
-            msg.Message.ConnectWebsocket = new ClientMessage.Types.ConnectWebsocket
+            var msg = new ClientMessage
             {
-                Address = aAddress,
-                BypassCertVerification = aIgnoreCert,
+                Message = new ClientMessage.Types.FFIMessage
+                {
+                    ConnectWebsocket = new ClientMessage.Types.ConnectWebsocket
+                    {
+                        Address = aAddress,
+                        BypassCertVerification = aIgnoreCert,
+                    }
+                }
             };
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
         internal static Task<ButtplugFFIServerMessage> SendDisconnect(ButtplugFFIMessageSorter aSorter, ButtplugFFIClientHandle aHandle, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            var msg = new ClientMessage();
-            msg.Message = new ClientMessage.Types.FFIMessage();
-            msg.Message.Disconnect = new ClientMessage.Types.Disconnect();
+            var msg = new ClientMessage
+            {
+                Message = new ClientMessage.Types.FFIMessage
+                {
+                    Disconnect = new ClientMessage.Types.Disconnect()
+                }
+            };
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
         internal static Task<ButtplugFFIServerMessage> SendStartScanning(ButtplugFFIMessageSorter aSorter, ButtplugFFIClientHandle aHandle, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            var msg = new ClientMessage();
-            msg.Message = new ClientMessage.Types.FFIMessage();
-            msg.Message.StartScanning = new ClientMessage.Types.StartScanning();
+            var msg = new ClientMessage
+            {
+                Message = new ClientMessage.Types.FFIMessage
+                {
+                    StartScanning = new ClientMessage.Types.StartScanning()
+                }
+            };
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
         internal static Task<ButtplugFFIServerMessage> SendStopScanning(ButtplugFFIMessageSorter aSorter, ButtplugFFIClientHandle aHandle, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            var msg = new ClientMessage();
-            msg.Message = new ClientMessage.Types.FFIMessage();
-            msg.Message.StopScanning = new ClientMessage.Types.StopScanning();
+            var msg = new ClientMessage
+            {
+                Message = new ClientMessage.Types.FFIMessage
+                {
+                    StopScanning = new ClientMessage.Types.StopScanning()
+                }
+            };
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
         internal static Task<ButtplugFFIServerMessage> SendStopAllDevices(ButtplugFFIMessageSorter aSorter, ButtplugFFIClientHandle aHandle, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            var msg = new ClientMessage();
-            msg.Message = new ClientMessage.Types.FFIMessage();
-            msg.Message.StopAllDevices = new ClientMessage.Types.StopAllDevices();
+            var msg = new ClientMessage
+            {
+                Message = new ClientMessage.Types.FFIMessage
+                {
+                    StopAllDevices = new ClientMessage.Types.StopAllDevices()
+                }
+            };
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
         internal static Task<ButtplugFFIServerMessage> SendPing(ButtplugFFIMessageSorter aSorter, ButtplugFFIClientHandle aHandle, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            var msg = new ClientMessage();
-            msg.Message = new ClientMessage.Types.FFIMessage();
-            msg.Message.Ping = new ClientMessage.Types.Ping();
+            var msg = new ClientMessage
+            {
+                Message = new ClientMessage.Types.FFIMessage
+                {
+                    Ping = new ClientMessage.Types.Ping()
+                }
+            };
             return SendClientMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
@@ -178,27 +206,31 @@ namespace Buttplug
 
         internal static Task<ButtplugFFIServerMessage> SendVibrateCmd(ButtplugFFIMessageSorter aSorter, ButtplugFFIDeviceHandle aHandle, uint aDeviceIndex, Dictionary<uint, double> aSpeeds, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            var msg = new DeviceMessage();
-            msg.Message = new DeviceMessage.Types.FFIMessage();
             var command_list = new List<DeviceMessage.Types.VibrateComponent>();
             foreach (var pair in aSpeeds)
             {
-                command_list.Add(new DeviceMessage.Types.VibrateComponent {
+                command_list.Add(new DeviceMessage.Types.VibrateComponent
+                {
                     Index = pair.Key,
                     Speed = pair.Value,
                 });
             }
-            msg.Index = aDeviceIndex;
-            var vibrate_cmd = new DeviceMessage.Types.VibrateCmd();
-            vibrate_cmd.Speeds.Add(command_list);
-            msg.Message.VibrateCmd = vibrate_cmd;
+            var cmd = new DeviceMessage.Types.VibrateCmd();
+            cmd.Speeds.Add(command_list);
+
+            var msg = new DeviceMessage
+            {
+                Index = aDeviceIndex,
+                Message = new DeviceMessage.Types.FFIMessage
+                {
+                    VibrateCmd = cmd
+                }
+            };
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
         internal static Task<ButtplugFFIServerMessage> SendRotateCmd(ButtplugFFIMessageSorter aSorter, ButtplugFFIDeviceHandle aHandle, uint aDeviceIndex, Dictionary<uint, (double, bool)> aRotations, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            var msg = new DeviceMessage();
-            msg.Message = new DeviceMessage.Types.FFIMessage();
             var command_list = new List<DeviceMessage.Types.RotateComponent>();
             foreach (var pair in aRotations)
             {
@@ -209,17 +241,22 @@ namespace Buttplug
                     Clockwise = pair.Value.Item2,
                 });
             }
-            msg.Index = aDeviceIndex;
             var cmd = new DeviceMessage.Types.RotateCmd();
             cmd.Rotations.Add(command_list);
-            msg.Message.RotateCmd = cmd;
+
+            var msg = new DeviceMessage
+            {
+                Index = aDeviceIndex,
+                Message = new DeviceMessage.Types.FFIMessage
+                {
+                    RotateCmd = cmd
+                }
+            };
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
         internal static Task<ButtplugFFIServerMessage> SendLinearCmd(ButtplugFFIMessageSorter aSorter, ButtplugFFIDeviceHandle aHandle, uint aDeviceIndex, Dictionary<uint, (uint, double)> aLinears, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            var msg = new DeviceMessage();
-            msg.Message = new DeviceMessage.Types.FFIMessage();
             var command_list = new List<DeviceMessage.Types.LinearComponent>();
             foreach (var pair in aLinears)
             {
@@ -230,40 +267,56 @@ namespace Buttplug
                     Position = pair.Value.Item2,
                 });
             }
-            msg.Index = aDeviceIndex;
             var cmd = new DeviceMessage.Types.LinearCmd();
             cmd.Movements.Add(command_list);
-            msg.Message.LinearCmd = cmd;
+
+            var msg = new DeviceMessage
+            {
+                Index = aDeviceIndex,
+                Message = new DeviceMessage.Types.FFIMessage
+                {
+                    LinearCmd = cmd
+                }
+            };
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
         internal static Task<ButtplugFFIServerMessage> SendStopDeviceCmd(ButtplugFFIMessageSorter aSorter, ButtplugFFIDeviceHandle aHandle, uint aDeviceIndex, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            var msg = new DeviceMessage();
-            msg.Message = new DeviceMessage.Types.FFIMessage();
-            msg.Index = aDeviceIndex;
-            var cmd = new DeviceMessage.Types.StopDeviceCmd();
-            msg.Message.StopDeviceCmd = cmd;
+            var msg = new DeviceMessage
+            {
+                Index = aDeviceIndex,
+                Message = new DeviceMessage.Types.FFIMessage
+                {
+                    StopDeviceCmd = new DeviceMessage.Types.StopDeviceCmd()
+                }
+            };
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
         internal static Task<ButtplugFFIServerMessage> SendBatteryLevelCmd(ButtplugFFIMessageSorter aSorter, ButtplugFFIDeviceHandle aHandle, uint aDeviceIndex, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            var msg = new DeviceMessage();
-            msg.Message = new DeviceMessage.Types.FFIMessage();
-            msg.Index = aDeviceIndex;
-            var cmd = new DeviceMessage.Types.BatteryLevelCmd();
-            msg.Message.BatteryLevelCmd = cmd;
+            var msg = new DeviceMessage
+            {
+                Index = aDeviceIndex,
+                Message = new DeviceMessage.Types.FFIMessage
+                {
+                    BatteryLevelCmd = new DeviceMessage.Types.BatteryLevelCmd()
+                }
+            };
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 
         internal static Task<ButtplugFFIServerMessage> SendRSSILevelCmd(ButtplugFFIMessageSorter aSorter, ButtplugFFIDeviceHandle aHandle, uint aDeviceIndex, ButtplugCallback aCallback, IntPtr aCallbackCtx)
         {
-            var msg = new DeviceMessage();
-            msg.Message = new DeviceMessage.Types.FFIMessage();
-            msg.Index = aDeviceIndex;
-            var cmd = new DeviceMessage.Types.RSSILevelCmd();
-            msg.Message.RssiLevelCmd = cmd;
+            var msg = new DeviceMessage
+            {
+                Index = aDeviceIndex,
+                Message = new DeviceMessage.Types.FFIMessage
+                {
+                    RssiLevelCmd = new DeviceMessage.Types.RSSILevelCmd()
+                }
+            };
             return SendDeviceMessage(aSorter, aHandle, msg, aCallback, aCallbackCtx);
         }
 

--- a/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
@@ -53,7 +53,7 @@ namespace Buttplug
         public static event EventHandler<string> LogMessage;
         // If we don't hold a reference to our log callback that lives for the lifetime of the process, we'll
         // get gc'd while in native code and that will be Bad (usually we'll get an exception before that).
-        private static ButtplugLogCallback LogCallback = OnLogMessage;
+        private readonly static ButtplugLogCallback LogCallback = OnLogMessage;
         private static ButtplugFFILogHandle LogHandle = null;
         private static bool LogHandleSet = false;
 

--- a/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Win32.SafeHandles;
+using System;
 using System.Runtime.InteropServices;
 
 namespace Buttplug
@@ -28,23 +29,14 @@ namespace Buttplug
         internal static extern void ButtplugActivateEnvLogger();
     }
 
-    internal class ButtplugFFILogHandle : SafeHandle
+    internal class ButtplugFFILogHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        public ButtplugFFILogHandle() : base(IntPtr.Zero, true) { }
-
-        public override bool IsInvalid
-        {
-            get { return this.handle == IntPtr.Zero; }
-        }
+        public ButtplugFFILogHandle() : base(true) { }
 
         protected override bool ReleaseHandle()
         {
             Console.WriteLine("Releasing handle?!");
-            if (!this.IsInvalid)
-            {
-                ButtplugFFILogCalls.ButtplugFreeLogHandle(handle);
-            }
-
+            ButtplugFFILogCalls.ButtplugFreeLogHandle(handle);
             return true;
         }
     }

--- a/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
@@ -17,7 +17,7 @@ namespace Buttplug
         Trace,
     }
 
-    internal class ButtplugFFILogCalls
+    internal static class ButtplugFFILogCalls
     {
         [DllImport("buttplug_rs_ffi")]
         internal static extern ButtplugFFILogHandle buttplug_create_log_handle(ButtplugLogCallback callback, IntPtr ctx, string level, bool aUseJSON);

--- a/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
@@ -44,6 +44,7 @@ namespace Buttplug
             {
                 ButtplugFFILogCalls.ButtplugFreeLogHandle(handle);
             }
+
             return true;
         }
     }
@@ -76,6 +77,7 @@ namespace Buttplug
                 {
                     throw new InvalidOperationException("Cannot set logging options twice (this is a bug, will be fixed at some point, see https://github.com/buttplugio/buttplug-rs-ffi/issues/23).");
                 }
+
                 LogHandle = ButtplugFFILogCalls.ButtplugCreateLogHandle(LogCallback, IntPtr.Zero, aMaxLevel.ToString(), aUseJSON);
                 LogHandleSet = true;
             }

--- a/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
@@ -53,9 +53,9 @@ namespace Buttplug
     {
         // If we don't hold a reference to our log callback that lives for the lifetime of the process, we'll
         // get gc'd while in native code and that will be Bad (usually we'll get an exception before that).
-        private readonly static ButtplugLogCallback LogCallback = OnLogMessage;
-        private static ButtplugFFILogHandle LogHandle = null;
-        private static bool LogHandleSet = false;
+        private readonly static ButtplugLogCallback _logCallback = OnLogMessage;
+        private static ButtplugFFILogHandle _logHandle = null;
+        private static bool _logHandleSet = false;
 
         public static event EventHandler<string> LogMessage;
 
@@ -73,20 +73,20 @@ namespace Buttplug
         {
             if (aMaxLevel != ButtplugLogLevel.Off)
             {
-                if (LogHandleSet)
+                if (_logHandleSet)
                 {
                     throw new InvalidOperationException("Cannot set logging options twice (this is a bug, will be fixed at some point, see https://github.com/buttplugio/buttplug-rs-ffi/issues/23).");
                 }
 
-                LogHandle = ButtplugFFILogCalls.ButtplugCreateLogHandle(LogCallback, IntPtr.Zero, aMaxLevel.ToString(), aUseJSON);
-                LogHandleSet = true;
+                _logHandle = ButtplugFFILogCalls.ButtplugCreateLogHandle(_logCallback, IntPtr.Zero, aMaxLevel.ToString(), aUseJSON);
+                _logHandleSet = true;
             }
             else
             {
-                if (LogHandle != null)
+                if (_logHandle != null)
                 {
-                    LogHandle.Dispose();
-                    LogHandle = null;
+                    _logHandle.Dispose();
+                    _logHandle = null;
                 }
             }
         }

--- a/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
@@ -50,12 +50,13 @@ namespace Buttplug
 
     public static class ButtplugFFILog
     {
-        public static event EventHandler<string> LogMessage;
         // If we don't hold a reference to our log callback that lives for the lifetime of the process, we'll
         // get gc'd while in native code and that will be Bad (usually we'll get an exception before that).
         private readonly static ButtplugLogCallback LogCallback = OnLogMessage;
         private static ButtplugFFILogHandle LogHandle = null;
         private static bool LogHandleSet = false;
+
+        public static event EventHandler<string> LogMessage;
 
         private static void ActivateEnvLogger()
         {

--- a/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
@@ -3,7 +3,6 @@ using System.Runtime.InteropServices;
 
 namespace Buttplug
 {
-    
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void ButtplugLogCallback(IntPtr ctx, string aLogMsg);
 
@@ -47,7 +46,6 @@ namespace Buttplug
             }
             return true;
         }
-
     }
 
     public static class ButtplugFFILog
@@ -90,5 +88,4 @@ namespace Buttplug
             }
         }
     }
-    
 }

--- a/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
@@ -18,14 +18,14 @@ namespace Buttplug
 
     internal static class ButtplugFFILogCalls
     {
-        [DllImport("buttplug_rs_ffi")]
-        internal static extern ButtplugFFILogHandle buttplug_create_log_handle(ButtplugLogCallback callback, IntPtr ctx, string level, bool aUseJSON);
+        [DllImport("buttplug_rs_ffi", EntryPoint = "buttplug_create_log_handle")]
+        internal static extern ButtplugFFILogHandle ButtplugCreateLogHandle(ButtplugLogCallback callback, IntPtr ctx, string level, bool aUseJSON);
 
-        [DllImport("buttplug_rs_ffi")]
-        internal static extern void buttplug_free_log_handle(IntPtr log_handle);
+        [DllImport("buttplug_rs_ffi", EntryPoint = "buttplug_free_log_handle")]
+        internal static extern void ButtplugFreeLogHandle(IntPtr log_handle);
 
-        [DllImport("buttplug_rs_ffi")]
-        internal static extern void buttplug_activate_env_logger();
+        [DllImport("buttplug_rs_ffi", EntryPoint = "buttplug_activate_env_logger")]
+        internal static extern void ButtplugActivateEnvLogger();
     }
 
     internal class ButtplugFFILogHandle : SafeHandle
@@ -42,7 +42,7 @@ namespace Buttplug
             Console.WriteLine("Releasing handle?!");
             if (!this.IsInvalid)
             {
-                ButtplugFFILogCalls.buttplug_free_log_handle(handle);
+                ButtplugFFILogCalls.ButtplugFreeLogHandle(handle);
             }
             return true;
         }
@@ -59,7 +59,7 @@ namespace Buttplug
 
         private static void ActivateEnvLogger()
         {
-            ButtplugFFILogCalls.buttplug_activate_env_logger();
+            ButtplugFFILogCalls.ButtplugActivateEnvLogger();
         }
 
         private static void OnLogMessage(IntPtr ctx, string aLogMessage)
@@ -75,7 +75,7 @@ namespace Buttplug
                 {
                     throw new InvalidOperationException("Cannot set logging options twice (this is a bug, will be fixed at some point, see https://github.com/buttplugio/buttplug-rs-ffi/issues/23).");
                 }
-                LogHandle = ButtplugFFILogCalls.buttplug_create_log_handle(LogCallback, IntPtr.Zero, aMaxLevel.ToString(), aUseJSON);
+                LogHandle = ButtplugFFILogCalls.ButtplugCreateLogHandle(LogCallback, IntPtr.Zero, aMaxLevel.ToString(), aUseJSON);
                 LogHandleSet = true;
             }
             else

--- a/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
@@ -45,7 +45,7 @@ namespace Buttplug
     {
         // If we don't hold a reference to our log callback that lives for the lifetime of the process, we'll
         // get gc'd while in native code and that will be Bad (usually we'll get an exception before that).
-        private readonly static ButtplugLogCallback _logCallback = OnLogMessage;
+        private static readonly ButtplugLogCallback _logCallback = OnLogMessage;
 
         private static ButtplugFFILogHandle _logHandle;
         private static bool _logHandleSet;

--- a/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
@@ -46,8 +46,9 @@ namespace Buttplug
         // If we don't hold a reference to our log callback that lives for the lifetime of the process, we'll
         // get gc'd while in native code and that will be Bad (usually we'll get an exception before that).
         private readonly static ButtplugLogCallback _logCallback = OnLogMessage;
-        private static ButtplugFFILogHandle _logHandle = null;
-        private static bool _logHandleSet = false;
+
+        private static ButtplugFFILogHandle _logHandle;
+        private static bool _logHandleSet;
 
         public static event EventHandler<string> LogMessage;
 

--- a/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFILog.cs
@@ -5,7 +5,7 @@ namespace Buttplug
 {
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    delegate void ButtplugLogCallback(IntPtr ctx, string aLogMsg);
+    public delegate void ButtplugLogCallback(IntPtr ctx, string aLogMsg);
 
     public enum ButtplugLogLevel
     {

--- a/csharp/ButtplugCSharpFFI/ButtplugFFIMessageSorter.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFIMessageSorter.cs
@@ -14,6 +14,12 @@ namespace Buttplug
     public class ButtplugFFIMessageSorter
     {
         /// <summary>
+        /// Stores messages waiting for reply from the server.
+        /// </summary>
+        private readonly ConcurrentDictionary<uint, TaskCompletionSource<ButtplugFFIServerMessage>> _waitingMsgs =
+            new ConcurrentDictionary<uint, TaskCompletionSource<ButtplugFFIServerMessage>>();
+
+        /// <summary>
         /// Holds count for message IDs, if needed.
         /// </summary>
         private int _counter;
@@ -22,12 +28,6 @@ namespace Buttplug
         /// Gets the next available message ID. In most cases, setting the message ID is done automatically.
         /// </summary>
         public uint NextMsgId => Convert.ToUInt32(Interlocked.Increment(ref _counter));
-
-        /// <summary>
-        /// Stores messages waiting for reply from the server.
-        /// </summary>
-        private readonly ConcurrentDictionary<uint, TaskCompletionSource<ButtplugFFIServerMessage>> _waitingMsgs =
-            new ConcurrentDictionary<uint, TaskCompletionSource<ButtplugFFIServerMessage>>();
 
         ~ButtplugFFIMessageSorter()
         {

--- a/csharp/ButtplugCSharpFFI/ButtplugFFIMessageSorter.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugFFIMessageSorter.cs
@@ -16,8 +16,7 @@ namespace Buttplug
         /// <summary>
         /// Stores messages waiting for reply from the server.
         /// </summary>
-        private readonly ConcurrentDictionary<uint, TaskCompletionSource<ButtplugFFIServerMessage>> _waitingMsgs =
-            new ConcurrentDictionary<uint, TaskCompletionSource<ButtplugFFIServerMessage>>();
+        private readonly ConcurrentDictionary<uint, TaskCompletionSource<ButtplugFFIServerMessage>> _waitingMsgs;
 
         /// <summary>
         /// Holds count for message IDs, if needed.
@@ -28,6 +27,11 @@ namespace Buttplug
         /// Gets the next available message ID. In most cases, setting the message ID is done automatically.
         /// </summary>
         public uint NextMsgId => Convert.ToUInt32(Interlocked.Increment(ref _counter));
+
+        public ButtplugFFIMessageSorter()
+        {
+            _waitingMsgs = new ConcurrentDictionary<uint, TaskCompletionSource<ButtplugFFIServerMessage>>();
+        }
 
         ~ButtplugFFIMessageSorter()
         {

--- a/csharp/ButtplugCSharpFFI/ButtplugHandshakeException.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugHandshakeException.cs
@@ -5,8 +5,17 @@ namespace Buttplug
     public class ButtplugHandshakeException : ButtplugException
     {
         /// <inheritdoc />
-        public ButtplugHandshakeException(string aMessage, Exception aInner = null)
-            : base(aMessage, aInner)
+        public ButtplugHandshakeException()
+        {
+        }
+
+        /// <inheritdoc />
+        public ButtplugHandshakeException(string aMessage) : base(aMessage)
+        {
+        }
+
+        /// <inheritdoc />
+        public ButtplugHandshakeException(string aMessage, Exception aInner) : base(aMessage, aInner)
         {
         }
     }

--- a/csharp/ButtplugCSharpFFI/ButtplugMessageAttributes.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugMessageAttributes.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Buttplug
+﻿namespace Buttplug
 {
     public class ButtplugMessageAttributes
     {

--- a/csharp/ButtplugCSharpFFI/ButtplugMessageAttributes.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugMessageAttributes.cs
@@ -13,7 +13,7 @@ namespace Buttplug
         public string[][] Patterns { get; }
         public string[] ActuatorType { get; }
 
-        public ButtplugMessageAttributes(uint aFeatureCount, uint[] aStepCount, Endpoint[] aEndpoints, uint[] aMaxDuration, string[][] aPatterns, string[] aActuatorType) 
+        public ButtplugMessageAttributes(uint aFeatureCount, uint[] aStepCount, Endpoint[] aEndpoints, uint[] aMaxDuration, string[][] aPatterns, string[] aActuatorType)
         {
             FeatureCount = aFeatureCount;
             StepCount = aStepCount;

--- a/csharp/ButtplugCSharpFFI/ButtplugMessageAttributes.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugMessageAttributes.cs
@@ -6,12 +6,12 @@ namespace Buttplug
 {
     public class ButtplugMessageAttributes
     {
-        public readonly uint FeatureCount;
-        public readonly uint[] StepCount;
-        public readonly Endpoint[] Endpoints;
-        public readonly uint[] MaxDuration;
-        public readonly string[][] Patterns;
-        public readonly string[] ActuatorType;
+        public uint FeatureCount { get; }
+        public uint[] StepCount { get; }
+        public Endpoint[] Endpoints { get; }
+        public uint[] MaxDuration { get; }
+        public string[][] Patterns { get; }
+        public string[] ActuatorType { get; }
 
         public ButtplugMessageAttributes(uint aFeatureCount, uint[] aStepCount, Endpoint[] aEndpoints, uint[] aMaxDuration, string[][] aPatterns, string[] aActuatorType) 
         {

--- a/csharp/ButtplugCSharpFFI/ButtplugMessageException.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugMessageException.cs
@@ -5,8 +5,17 @@ namespace Buttplug
     public class ButtplugMessageException : ButtplugException
     {
         /// <inheritdoc />
-        public ButtplugMessageException(string aMessage, Exception aInner = null)
-            : base(aMessage, aInner)
+        public ButtplugMessageException()
+        {
+        }
+
+        /// <inheritdoc />
+        public ButtplugMessageException(string aMessage) : base(aMessage)
+        {
+        }
+
+        /// <inheritdoc />
+        public ButtplugMessageException(string aMessage, Exception aInner) : base(aMessage, aInner)
         {
         }
     }

--- a/csharp/ButtplugCSharpFFI/ButtplugPingException.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugPingException.cs
@@ -5,8 +5,17 @@ namespace Buttplug
     public class ButtplugPingException : ButtplugException
     {
         /// <inheritdoc />
-        public ButtplugPingException(string aMessage, Exception aInner = null)
-            : base(aMessage, aInner)
+        public ButtplugPingException()
+        {
+        }
+
+        /// <inheritdoc />
+        public ButtplugPingException(string aMessage) : base(aMessage)
+        {
+        }
+
+        /// <inheritdoc />
+        public ButtplugPingException(string aMessage, Exception aInner) : base(aMessage, aInner)
         {
         }
     }

--- a/csharp/ButtplugCSharpFFI/ButtplugUnknownException.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugUnknownException.cs
@@ -2,7 +2,7 @@
 
 namespace Buttplug
 {
-    class ButtplugUnknownException : ButtplugException
+    public class ButtplugUnknownException : ButtplugException
     {
         /// <inheritdoc />
         public ButtplugUnknownException()

--- a/csharp/ButtplugCSharpFFI/ButtplugUnknownException.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugUnknownException.cs
@@ -4,8 +4,18 @@ namespace Buttplug
 {
     class ButtplugUnknownException : ButtplugException
     {
-        public ButtplugUnknownException(string aMessage, Exception aInner = null)
-            : base(aMessage, aInner)
+        /// <inheritdoc />
+        public ButtplugUnknownException()
+        {
+        }
+
+        /// <inheritdoc />
+        public ButtplugUnknownException(string aMessage) : base(aMessage)
+        {
+        }
+
+        /// <inheritdoc />
+        public ButtplugUnknownException(string aMessage, Exception aInner) : base(aMessage, aInner)
         {
         }
     }

--- a/csharp/ButtplugCSharpFFI/ButtplugUtils.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugUtils.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Buttplug
 {
-    public class ButtplugUtils
+    public static class ButtplugUtils
     {
         public static void ActivateEnvLogger()
         {

--- a/csharp/ButtplugCSharpFFI/ButtplugUtils.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugUtils.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Buttplug
+﻿namespace Buttplug
 {
     public static class ButtplugUtils
     {

--- a/csharp/ButtplugCSharpFFI/ButtplugWebsocketConnectorOptions.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugWebsocketConnectorOptions.cs
@@ -6,7 +6,7 @@ namespace Buttplug
 {
     public class ButtplugWebsocketConnectorOptions
     {
-        public Uri NetworkAddress;
+        public Uri NetworkAddress { get; set; }
 
         public ButtplugWebsocketConnectorOptions(Uri aAddress)
         {

--- a/csharp/ButtplugCSharpFFI/ButtplugWebsocketConnectorOptions.cs
+++ b/csharp/ButtplugCSharpFFI/ButtplugWebsocketConnectorOptions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Buttplug
 {

--- a/csharp/ButtplugCSharpFFI/DeviceAddedEventArgs.cs
+++ b/csharp/ButtplugCSharpFFI/DeviceAddedEventArgs.cs
@@ -7,7 +7,7 @@
 namespace Buttplug
 {
     /// <summary>
-    /// Event wrapper for Buttplug DeviceAdded or DeviceRemoved messages. Used when the the server
+    /// Event wrapper for Buttplug DeviceAdded or DeviceRemoved messages. Used when the server
     /// informs the client of a device connecting or disconnecting.
     /// </summary>
     public class DeviceAddedEventArgs

--- a/csharp/ButtplugCSharpFFI/DeviceAddedEventArgs.cs
+++ b/csharp/ButtplugCSharpFFI/DeviceAddedEventArgs.cs
@@ -16,7 +16,7 @@ namespace Buttplug
         /// The client representation of a Buttplug Device.
         /// </summary>
         //public readonly ButtplugClientDevice Device;
-        public readonly ButtplugClientDevice Device;
+        public ButtplugClientDevice Device { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DeviceAddedEventArgs"/> class.

--- a/csharp/ButtplugCSharpFFI/DeviceRemovedEventArgs.cs
+++ b/csharp/ButtplugCSharpFFI/DeviceRemovedEventArgs.cs
@@ -7,7 +7,7 @@
 namespace Buttplug
 {
     /// <summary>
-    /// Event wrapper for Buttplug DeviceAdded or DeviceRemoved messages. Used when the the server
+    /// Event wrapper for Buttplug DeviceAdded or DeviceRemoved messages. Used when the server
     /// informs the client of a device connecting or disconnecting.
     /// </summary>
     public class DeviceRemovedEventArgs

--- a/csharp/ButtplugCSharpFFI/DeviceRemovedEventArgs.cs
+++ b/csharp/ButtplugCSharpFFI/DeviceRemovedEventArgs.cs
@@ -15,7 +15,7 @@ namespace Buttplug
         /// <summary>
         /// The client representation of a Buttplug Device.
         /// </summary>
-        public readonly ButtplugClientDevice Device;
+        public ButtplugClientDevice Device { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DeviceRemovedEventArgs"/> class.

--- a/csharp/ButtplugCSharpFFITest/Program.cs
+++ b/csharp/ButtplugCSharpFFITest/Program.cs
@@ -102,7 +102,7 @@ namespace ButtplugCSharpFFITest
             await WaitForKey();
         }
 
-        static void Main(string[] args)
+        public static void Main(string[] args)
         {
             // ButtplugUtils.ActivateEnvLogger();
              RunExample().Wait();

--- a/csharp/ButtplugCSharpFFITest/Program.cs
+++ b/csharp/ButtplugCSharpFFITest/Program.cs
@@ -12,7 +12,7 @@ namespace ButtplugCSharpFFITest
             Console.WriteLine("Press any key to continue.");
             while (!Console.KeyAvailable)
             {
-                await Task.Delay(10);
+                await Task.Delay(10).ConfigureAwait(false);
             }
             Console.ReadKey(true);
         }
@@ -56,7 +56,7 @@ namespace ButtplugCSharpFFITest
             };
             var options = new Buttplug.ButtplugEmbeddedConnectorOptions();
             //options.AllowRawMessages = true;
-            await client.ConnectAsync(options);
+            await client.ConnectAsync(options).ConfigureAwait(false);
             /*
             await client.ConnectAsync(new Buttplug.ButtplugWebsocketConnectorOptions(new Uri("ws://localhost:12345")));
             await client.StartScanningAsync();
@@ -72,11 +72,11 @@ namespace ButtplugCSharpFFITest
             await WaitForKey();
             await client.ConnectAsync(new Buttplug.ButtplugWebsocketConnectorOptions(new Uri("ws://localhost:12345")));
             */
-            await client.StartScanningAsync();
+            await client.StartScanningAsync().ConfigureAwait(false);
             Console.WriteLine($"Is Scanning: {client.IsScanning}");
-            await WaitForKey();
+            await WaitForKey().ConfigureAwait(false);
 //            ButtplugFFILog.SetLogOptions(ButtplugLogLevel.Debug, true);
-            await client.StopScanningAsync();
+            await client.StopScanningAsync().ConfigureAwait(false);
             /*
             while (true) {
                 foreach (var device in client.Devices) {
@@ -93,13 +93,13 @@ namespace ButtplugCSharpFFITest
                 }
             }
             */
-            await WaitForKey();
+            await WaitForKey().ConfigureAwait(false);
             Console.WriteLine("killing log?");
             ButtplugFFILog.SetLogOptions(ButtplugLogLevel.Off, true);
-            await WaitForKey();
+            await WaitForKey().ConfigureAwait(false);
             client.Dispose();
             client = null;
-            await WaitForKey();
+            await WaitForKey().ConfigureAwait(false);
         }
 
         public static void Main(string[] args)

--- a/csharp/ButtplugCSharpFFITest/Program.cs
+++ b/csharp/ButtplugCSharpFFITest/Program.cs
@@ -27,7 +27,7 @@ namespace ButtplugCSharpFFITest
             ButtplugFFILog.LogMessage += (aObj, aMsg) => { Console.WriteLine($"LOG: {aMsg}"); };
             ButtplugFFILog.SetLogOptions(ButtplugLogLevel.Info, true);
             var client = new ButtplugClient("Test Client");
-            client.DeviceAdded += async (obj, args) =>
+            client.DeviceAdded += (obj, args) =>
             {
                 var device = args.Device;
                 Console.WriteLine($"Device Added: {device.Name}");

--- a/csharp/ButtplugCSharpFFITest/Program.cs
+++ b/csharp/ButtplugCSharpFFITest/Program.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 
 namespace ButtplugCSharpFFITest
 {
-    class Program
+    public static class Program
     {
         private static async Task WaitForKey()
         {


### PR DESCRIPTION
Code style changes, from ~110 messages/warnings to ~20, most of the ones left are in the test project.

Technically possible breaking changes:
* refactor: Use public properties instead of public fields (26138cb)
* refactor: RCS1090: Add call to 'ConfigureAwait' (f890851)
* refactor: Simplify SafeHandles (78bbeea)

Fixes #75