### PR TITLE
Add node native bindings and prebuild

### DIFF
--- a/js/.gitignore
+++ b/js/.gitignore
@@ -1,1 +1,5 @@
-src/buttplug-rs-ffi
+src/browser/buttplug-rs-ffi
+build/
+prebuilds/
+bin/
+yarn.error.log

--- a/js/.npmignore
+++ b/js/.npmignore
@@ -1,4 +1,6 @@
-dist/module/buttplug_rs_ffi_bg_web.js
+bin
+build
 node_modules
 src
 scripts
+!scripts/install_core.js

--- a/js/binding.gyp
+++ b/js/binding.gyp
@@ -1,0 +1,34 @@
+{
+    "targets": [{
+        "target_name": "binding",
+        "sources": ["src/node/binding.cpp"],
+        "include_dirs": [
+            "<!@(node -p \"require('node-addon-api').include\")",
+        ],
+        "dependencies": [
+            "<!(node -p \"require('node-addon-api').gyp\")"
+        ],
+        'cflags!': [ '-fno-exceptions' ],
+        'cflags_cc!': [ '-fno-exceptions' ],
+        'xcode_settings': {
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'CLANG_CXX_LIBRARY': 'libc++',
+            'MACOSX_DEPLOYMENT_TARGET': '10.7',
+        },
+        'msvs_settings': {
+            'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+        },
+        "conditions": [
+            ['OS=="linux"', {
+                "cflags": [ "-std=c++11", "-Wall" ]
+            }, {
+                "cflags": [ "-std=c++11", "-stdlib=libc++", "-Wall" ]
+            }],
+            ['OS=="win"', {
+                "sources": [
+                    "src/node/win32-dlfcn.cpp"
+                ]
+            }]
+        ]
+    }]
+}

--- a/js/package.json
+++ b/js/package.json
@@ -14,42 +14,70 @@
   "bugs": {
     "url": "https://github.com/buttplugio/buttplug-rs-ffi/issues"
   },
+  "ffi-version": "2.0.2",
   "scripts": {
+    "install": "node-gyp-build && node scripts/install_core.js",
+    "prebuild:win32": "prebuildify --napi --tag-uv --tag-armv --platform win32 && rimraf build",
+    "prebuild:darwin": "prebuildify --napi --tag-uv --tag-armv --platform darwin && rimraf build",
+    "prebuild:linux": "prebuildify --napi --tag-uv --tag-armv --platform linux && rimraf build",
+    "prebuild:all": "yarn prebuild:win32 && yarn prebuild:darwin && yarn prebuild:linux",
+    "prebuild": "prebuildify --napi --tag-uv --tag-armv",
     "dev": "webpack-dev-server --hot --config webpack.base.js --env development",
-    "build:publish": "rimraf dist && yarn build:rust && yarn build:webpack && yarn build:webpack:production",
-    "build:rust": "rimraf src/buttplug-rs-ffi && cd ../ffi && cross-env RUSTFLAGS=\"--cfg=web_sys_unstable_apis\" wasm-pack build -d../js/src/buttplug-rs-ffi --release -- --features wasm --no-default-features && cd ../js && node scripts/modularize.cjs wasm-pack && rimraf src/buttplug-rs-ffi/.gitignore src/buttplug-rs-ffi/package.json src/buttplug-rs-ffi/README.md",
-    "build:main": "tsc -p tsconfig.json && copyfiles -u 1 \"src/**/*.js\" dist/module && copyfiles -u 1 \"src/**/*.d.ts\" dist/module && copyfiles -u 1 \"src/**/*.wasm\" dist/module",
+    "build:rust:node": "cd ../ffi && cargo build --release && cd ../js && node scripts/install_core.js --from ../ffi/target/release",
+    "build:rust:browser": "rimraf src/browser/buttplug-rs-ffi && cd ../ffi && cross-env RUSTFLAGS=\"--cfg=web_sys_unstable_apis\" wasm-pack build -d../js/src/browser/buttplug-rs-ffi --release -- --features wasm --no-default-features && cd ../js && rimraf src/browser/buttplug-rs-ffi/.gitignore src/browser/buttplug-rs-ffi/package.json src/browser/buttplug-rs-ffi/README.md",
+    "build:rust": "yarn build:rust:node && yarn build:rust:browser",
     "build:proto": "pbjs -t static-module -w es6 -o src/buttplug_ffi.js ../protobuf_schemas/buttplug_rs_ffi.proto && node scripts/modularize.cjs pbjs && pbjs -t static-module ../protobuf_schemas/buttplug_rs_ffi.proto | pbts -o src/buttplug_ffi.d.ts -",
-    "build:webpack": "yarn build:main && webpack --progress --config webpack.base.cjs --env development",
-    "build:webpack:production": "webpack --progress --config webpack.base.cjs --env production"
+    "build:node:rust": "node scripts/install_core.js",
+    "build:node:gyp": "node-gyp-build",
+    "build:node:tsc": "tsc -p tsconfig.json && copyfiles -u 1 \"src/**/*.{js,d.ts}\" --exclude \"src/browser/**/*.*\" dist/node",
+    "build:node": "yarn build:node:rust && yarn build:node:gyp && yarn build:node:tsc",
+    "clean:node:gyp": "rimraf build && rimraf prebuilds",
+    "clean:node": "rimraf dist/node && rimraf bin && yarn clean:node:gyp",
+    "test:node": "yarn build:node && node scripts/test_node.cjs",
+    "build:browser:rust": "yarn build:rust:browser && copyfiles -u 1 \"src/**/*.wasm\" dist/browser",
+    "build:browser:webpack": "yarn build:webpack",
+    "build:browser:webpack:production": "yarn build:webpack:production",
+    "build:browser": "yarn build:browser:rust && yarn build:browser:webpack",
+    "build:browser:production": "yarn build:browser:rust && yarn build:browser:webpack:production",
+    "clean:browser": "rimraf dist/browser && rimraf src/browser/buttplug-rs-ffi",
+    "build:webpack": "webpack --progress --config webpack.base.cjs --env development",
+    "build:webpack:production": "webpack --progress --config webpack.base.cjs --env production",
+    "build": "yarn build:proto && yarn build:node && yarn build:webpack",
+    "build:production": "yarn build:proto && yarn build:node && yarn build:webpack:production",
+    "build:publish": "rimraf dist && rimraf bin && rimraf build && yarn build:production",
+    "clean": "yarn clean:node && yarn clean:browser && rimraf dist"
   },
   "sideEffects": "false",
   "type": "module",
-  "main": "./dist/module/index.js",
+  "main": "./dist/node/index.js",
   "exports": {
-    "node": "./dist/module/index.js",
-    "browser": "./dist/web/buttplug.min.js"
+    "node": "./dist/node/index.js",
+    "browser": "./dist/browser/buttplug.min.js"
   },
   "imports": {
-    "#buttplug_rs_ffi_bg": {
-      "node": "./dist/module/buttplug-rs-ffi/buttplug_rs_ffi_bg_node.js"
+    "#ffi_wrap": {
+      "node": "./dist/node/node/ffi_wrap.js"
     }
   },
-  "types": "./dist/module/index.d.ts",
+  "types": "./dist/node/index.d.ts",
   "dependencies": {
+    "node-addon-api": "^4.0.0",
+    "node-gyp-build": "^4.2.3",
     "protobufjs": "^6.10.2",
     "websocket": "^1.0.34"
   },
   "devDependencies": {
+    "@types/node": "15",
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",
     "fork-ts-checker-webpack-plugin": "^6.1.0",
     "html-loader": "^1.3.2",
+    "prebuildify": "^4.1.2",
     "rimraf": "^3.0.2",
     "ts-loader": "^8",
     "ts-node": "^9.1.1",
     "ts-proto": "^1.80.1",
-    "typescript": "^4.1.5",
+    "typescript": "4.3",
     "uglify-js": "^3.12.7",
     "webpack": "^4",
     "webpack-cli": "^3",

--- a/js/scripts/install_core.js
+++ b/js/scripts/install_core.js
@@ -1,0 +1,323 @@
+// @ts-check
+/// <reference lib="esnext" />
+import https from "https";
+import os from "os";
+import path from "path";
+import { copyFile, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "fs/promises";
+import { exec } from "child_process";
+import { pipeline } from "stream/promises";
+import { fileURLToPath, URL } from "url";
+import { createWriteStream } from "fs";
+import util from "util";
+
+const MAX_REDIRECTS = 10;
+const execAsync = util.promisify(exec);
+const packageDir = fileURLToPath(new URL("..", import.meta.url));
+
+/**
+ * @typedef ParsedArgs
+ * @property {string} [version]
+ * @property {string} [platform]
+ * @property {string} [arch]
+ * @property {boolean} [force]
+ * @property {string} [from]
+ */
+
+/**
+ * @typedef Release
+ * @property {string} version
+ * @property {"darwin" | "win32" | "linux"} platform
+ * @property {"x64"} arch
+ */
+
+/**
+ * @typedef CacheInfo
+ * @property {string} [version]
+ * @property {string} [etag]
+ * @property {string} [date]
+ */
+
+function parseArgs() {
+    /** @type {ParsedArgs} */
+    const parsedArgs = {
+        force: false,
+        version: undefined,
+        platform: undefined,
+        arch: undefined,
+        from: undefined,
+    };
+    const args = process.argv.slice(2);
+    let arg;
+    while ((arg = args.shift()) !== undefined) {
+        const argLower = arg.toLowerCase();
+        switch (argLower) {
+            case "--force":
+            case "--no-force": {
+                const value = !argLower.startsWith("--no-");
+                parsedArgs[argLower.slice(value ? 2 : 5)] = value;
+                break;
+            }
+            case "--version":
+            case "--platform":
+            case "--arch":
+            case "--from": {
+                const value = args.shift();
+                if (value === undefined) throw new Error(`Argument '${argLower}' requires a value`);
+                parsedArgs[argLower.slice(2)] = value;
+                break;
+            }
+            default:
+                throw new Error(`Unexpected argument: '${arg}'`);
+        }
+    }
+    return parsedArgs;
+}
+
+/**
+ * @param {*} version
+ * @returns {ffiVersion is `${number}.${number}.${number}`}
+ */
+function isSupportedFfiVersion(version) {
+    return typeof version === "string" && /^\d+\.\d+\.\d+$/.test(version);
+}
+
+/**
+ * @param {string} platform
+ * @returns {platform is "darwin" | "linux" | "win32"}
+ */
+function isSupportedPlatform(platform) {
+    switch (platform) {
+        case "darwin":
+        case "linux":
+        case "win32":
+            return true;
+        default:
+            return false;
+    }
+}
+
+/**
+ * @param {string} arch
+ * @returns {arch is "x64"}
+ */
+function isSupportedArch(arch) {
+    return arch === "x64";
+}
+
+async function readFfiVersionFromPackageJson() {
+    const packageJsonFile = path.resolve(packageDir, "package.json");
+    const packageJson = JSON.parse((await readFile(packageJsonFile, "utf8")).toString());
+    return packageJson["ffi-version"];
+}
+
+/**
+ * @param {Release} release
+ */
+function getReleaseUrl({version, platform, arch}) {
+    const platformName =
+        platform === "darwin" ? "macos" :
+        platform === "win32" ? "win" :
+        "linux";
+    if (!platformName) {
+        throw new Error(`Unsupported platform: ${platform}`);
+    }
+    return `https://github.com/buttplugio/buttplug-rs-ffi/releases/download/core-${version}/buttplug_rs_ffi-lib-${platformName}-${arch}-${version}.zip`;
+}
+
+/**
+ * @param {string} url
+ * @param {object} [options]
+ * @param {import("http").OutgoingHttpHeaders} [options.headers]
+ * @returns {Promise<import("http").IncomingMessage>}
+ */
+function fetch(url, { headers } = {}) {
+    return new Promise((resolve, reject) => {
+        let redirectCount = 0;
+        /**
+         * @param {string} url
+         */
+        const start = url => {
+            https.get(url, { headers }, message => {
+                try {
+                    if (message.statusCode === 301 || message.statusCode === 302) {
+                        if (redirectCount >= MAX_REDIRECTS) {
+                            throw new Error("Too many redirects.");
+                        }
+                        if (!message.headers.location) {
+                            throw new Error("Invalid redirect location.");
+                        }
+                        redirectCount++;
+                        const location = message.url ? new URL(message.headers.location, message.url).href : message.headers.location;
+                        return start(location);
+                    }
+                    if (message.statusCode !== 200) {
+                        throw new Error(`Download failed: ${message.statusCode} - ${message.statusMessage}`);
+                    }
+                    return resolve(message);
+                }
+                catch (e) {
+                    reject(e);
+                }
+            })
+            .on("error", reject);
+        };
+        start(url);
+    });
+}
+
+/**
+ * @param {import("http").IncomingMessage} response
+ * @param {string} releaseFile
+ * @returns {Promise<CacheInfo>}
+ */
+async function downloadPackage(response, releaseFile) {
+    console.log(`Downloading '${path.basename(releaseFile)}...`);
+    await pipeline(response, createWriteStream(releaseFile, { autoClose: true }));
+    return {
+        etag: response.headers.etag,
+        date: response.headers.date
+    };
+}
+
+/**
+ * @param {string} releaseFile
+ * @param {string} releaseOutDir
+ */
+async function unzipPackage(releaseFile, releaseOutDir) {
+    console.log(`Extracting '${path.basename(releaseFile)}...`);
+    await execAsync(`npx extract-zip "${releaseFile}" "${releaseOutDir}"`);
+}
+
+/**
+ * @param {string} file
+ */
+async function rimraf(file) {
+    try {
+        await rm(file, { recursive: true, force: true });
+    }
+    catch {
+    }
+}
+
+/**
+ * @param {string} sourceDir
+ * @param {string} targetDir
+ * @param {RegExp} [include]
+ * @param {RegExp} [exclude]
+ */
+async function copyFiles(sourceDir, targetDir, include, exclude) {
+    let hasCreatedDir = false;
+    for (const entry of await readdir(sourceDir, { withFileTypes: true })) {
+        const sourceFile = path.join(sourceDir, entry.name);
+        const targetFile = path.join(targetDir, entry.name);
+        if (entry.isDirectory()) {
+            await copyFiles(sourceFile, targetFile, include, exclude);
+        }
+        else if (entry.isFile()) {
+            if (!include || include.test(sourceFile)) {
+                if (!exclude || !exclude.test(sourceFile)) {
+                    if (!hasCreatedDir) {
+                        hasCreatedDir = true;
+                        try { await mkdir(targetDir, { recursive: true }); } catch { }
+                    }
+                    await copyFile(sourceFile, targetFile);
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @param {Release} release
+ */
+function getPackageBinDir(release) {
+    return path.join(packageDir, "bin", `${release.platform}-${release.arch}`);
+}
+
+/**
+ * @param {Release} release
+ * @returns {Promise<CacheInfo | undefined>}
+ */
+async function getCacheInfo(release) {
+    const packageBinDir = getPackageBinDir(release);
+    const cacheInfoFile = path.join(packageBinDir, ".cache");
+    try {
+        return JSON.parse((await readFile(cacheInfoFile, "utf8")).toString());
+    }
+    catch {
+    }
+}
+
+/**
+ * @param {string} sourceDir
+ * @param {Release} release
+ * @param {CacheInfo} [cacheInfo]
+ */
+async function copyPackage(sourceDir, release, cacheInfo) {
+    const packageBinDir = getPackageBinDir(release);
+    await rimraf(packageBinDir);
+    await copyFiles(sourceDir, packageBinDir, /*include*/ /\.(dll|so|dylib|pdb|dbg)$/, /*exclude*/ /[\\/](\.fingerprint|build|deps|examples|incremental)[\\/]/);
+    if (cacheInfo) {
+        cacheInfo.version = release.version;
+        await writeFile(path.join(packageBinDir, ".cache"), JSON.stringify(cacheInfo));
+    }
+}
+
+async function main() {
+    const args = parseArgs();
+    const version = args.version || await readFfiVersionFromPackageJson();
+    const platform = args.platform || process.platform;
+    const arch = args.arch || process.arch;
+    if (!isSupportedFfiVersion(version)) throw new Error(`Unsupported ffi-version in package.json: ${version}`);
+    if (!isSupportedPlatform(platform)) throw new Error(`Unsupported platform: ${platform}`);
+    if (!isSupportedArch(arch)) throw new Error(`Unsupported architecture: ${arch}`);
+
+    /** @type {Release} */
+    const release = { version, platform, arch };
+    if (args.from) {
+        await copyPackage(args.from, release);
+        console.log("ffi library updated");
+    }
+    else {
+        const cacheInfo = await getCacheInfo(release);
+
+        /** @type {"yes" | "no" | "maybe"} */
+        let needsUpdate = args.force ? "yes" : "maybe";
+        if (needsUpdate === "maybe" && cacheInfo?.version === release.version) {
+            needsUpdate = "no";
+        }
+
+        const releaseUrl = getReleaseUrl(release);
+        if (needsUpdate !== "no") {
+            const response = await fetch(releaseUrl, {
+                headers: needsUpdate === "maybe" ? {
+                    ...(cacheInfo?.etag ? { etag: cacheInfo.etag } : undefined),
+                    ...(cacheInfo?.date ? { "if-modified-since": cacheInfo.date } : undefined)
+                } : undefined
+            });
+            if (needsUpdate === "maybe" && response.statusCode === 304) {
+                needsUpdate = "no";
+            }
+            if (needsUpdate !== "no") {
+                const releaseName = path.basename(releaseUrl);
+                const releaseDir = await mkdtemp(`${os.tmpdir()}/${path.basename(releaseName, ".zip")}-`);
+                try {
+                    console.log(releaseDir);
+                    const releaseFile = path.join(releaseDir, releaseName);
+                    const releaseOutDir = path.join(releaseDir, "archive");
+                    const cacheInfo = await downloadPackage(response, releaseFile);
+                    await unzipPackage(releaseFile, releaseOutDir);
+                    await copyPackage(releaseOutDir, release, cacheInfo);
+                }
+                finally {
+                    await rimraf(releaseDir);
+                }
+                console.log("ffi library updated");
+                return;
+            }
+        }
+        console.log("ffi library update not required");
+    }
+}
+
+await main();

--- a/js/scripts/jsconfig.json
+++ b/js/scripts/jsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions" : {
+    "lib": ["esnext"],
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "declaration": true,
+    "noEmit": true,
+  }
+}

--- a/js/src/browser/ffi_wrap.ts
+++ b/js/src/browser/ffi_wrap.ts
@@ -1,0 +1,32 @@
+function must_run_init(): never {
+    throw new Error("Must run buttplugInit() async before calling any Buttplug methods!");
+}
+
+let buttplug_has_init_run = false;
+
+export let buttplug_create_protobuf_client: (client_name: string, callback: (buf: Uint8Array) => void, callback_context: any) => number = must_run_init;
+export let buttplug_free_client: (client_ptr: number) => void = must_run_init;
+export let buttplug_client_protobuf_message: (client_ptr: number, buf: Uint8Array, callback: (buf: Uint8Array) => void, callback_context: any) => void = must_run_init;
+export let buttplug_create_device: (client_ptr: number, device_index: number) => number = must_run_init;
+export let buttplug_free_device: (device_ptr: number) => void = must_run_init;
+export let buttplug_device_protobuf_message: (device_ptr: number, buf: Uint8Array, callback: (buf: Uint8Array) => void, callback_context: any) => void = must_run_init;
+export let buttplug_activate_env_logger: (log_level?: string) => void = must_run_init;
+
+export async function buttplugInit() {
+    if (buttplug_has_init_run) {
+        console.log("buttplugInit function has already run successfully. This only needs to be run once, but doesn't affect anything (other than printing this message) if called again.");
+        return;
+    }
+    let index = await import(/* webpackPrefetch: 1 */ "./buttplug-rs-ffi/buttplug_rs_ffi.js").catch((e) => {
+        console.log(e);
+        return Promise.reject(e);
+    });
+    buttplug_create_protobuf_client = index.buttplug_create_protobuf_client;
+    buttplug_free_client = index.buttplug_free_client;
+    buttplug_client_protobuf_message = index.buttplug_client_protobuf_message;
+    buttplug_activate_env_logger = index.buttplug_activate_env_logger;
+    buttplug_free_device = index.buttplug_free_device;
+    buttplug_create_device = index.buttplug_create_device;
+    buttplug_device_protobuf_message = index.buttplug_device_protobuf_message;
+    buttplug_has_init_run = true;
+}

--- a/js/src/ffi_wrap.d.ts
+++ b/js/src/ffi_wrap.d.ts
@@ -1,0 +1,10 @@
+declare module "#ffi_wrap" {
+    function buttplugInit(): Promise<void>;
+    function buttplug_create_protobuf_client(client_name: string, callback: (buf: Uint8Array) => void): number;
+    function buttplug_free_client(client_ptr: number): void;
+    function buttplug_client_protobuf_message(client_ptr: number, buf: Uint8Array, callback: (buf: Uint8Array) => void): void;
+    function buttplug_create_device(client_ptr: number, device_index: number): number;
+    function buttplug_free_device(device_ptr: number): void;
+    function buttplug_device_protobuf_message(device_ptr: number, buf: Uint8Array, callback: (buf: Uint8Array) => void): void;
+    function buttplug_activate_env_logger(log_level?: string): void;
+}

--- a/js/src/node/binding.cpp
+++ b/js/src/node/binding.cpp
@@ -1,0 +1,451 @@
+#include "binding.h"
+#include <iostream>
+
+// Function pointers to functions dynamically loaded from buttplug_rs_ffi.dll.
+#define BUTTPLUG_RS_FFI_FUNCTION_LIST(V)    \
+  V(buttplug_create_protobuf_client)        \
+  V(buttplug_free_client)                   \
+  V(buttplug_client_protobuf_message)       \
+  V(buttplug_create_device)                 \
+  V(buttplug_device_protobuf_message)       \
+  V(buttplug_free_device)                   \
+  V(buttplug_activate_env_logger)
+
+#define DLL_FUNC_TYPE(name) _##name##_
+#define DLL_FUNC_VAR(name) _##name
+
+#ifndef IN
+#define IN
+#endif
+#ifndef VOID
+#define VOID void
+#endif
+
+typedef VOID (__stdcall* FFICallback)(void* ctx, const uint8_t* buf, uint32_t buf_length);
+
+using DLL_FUNC_TYPE(buttplug_create_protobuf_client) = void*(__stdcall*)(
+    IN PCSTR client_name_ptr,
+    IN FFICallback callback,
+    IN void* callback_context
+);
+
+using DLL_FUNC_TYPE(buttplug_free_client) = VOID(__stdcall*)(
+    IN void* client_ptr
+);
+
+using DLL_FUNC_TYPE(buttplug_client_protobuf_message) = VOID(__stdcall*)(
+    IN void* client_ptr,
+    IN uint8_t* buf,
+    IN uint32_t buf_len,
+    IN FFICallback callback,
+    IN void* callback_context
+);
+
+using DLL_FUNC_TYPE(buttplug_create_device) = void*(__stdcall*)(
+    IN void* client_ptr,
+    IN uint32_t device_index
+);
+
+using DLL_FUNC_TYPE(buttplug_device_protobuf_message) = VOID(__stdcall*)(
+    IN void* device_ptr,
+    IN uint8_t* buf,
+    IN int32_t buf_len,
+    IN FFICallback callback,
+    IN void* callback_context
+);
+
+using DLL_FUNC_TYPE(buttplug_free_device) = VOID(__stdcall*)(
+    IN void* device_ptr
+);
+
+using DLL_FUNC_TYPE(buttplug_activate_env_logger) = VOID(__stdcall*)(VOID);
+
+#undef IN
+#undef VOID
+
+class Callback {
+    public:
+        Callback(Env env, Function callback, const std::string resource_name, bool persistent_) :
+            tsfn(ThreadSafeFunction::New(env, callback, resource_name, 0, 1)),
+            persistent(persistent_) {}
+        ThreadSafeFunction tsfn;
+        bool persistent;
+};
+
+class ClientData {
+    public:
+        ClientData(void* client_ptr_, Callback* cb_) : client_ptr(client_ptr_), cb(cb_) {}
+        void* client_ptr;
+        Callback* cb;
+};
+
+class ButtplugAddon : public Addon<ButtplugAddon> {
+    public:
+        ButtplugAddon(Env env_, Object exports);
+        ~ButtplugAddon();
+
+    private:
+        Value Initialize(const CallbackInfo& args);
+        Value ButtplugCreateProtobufClient(const CallbackInfo& args);
+        Value ButtplugFreeClient(const CallbackInfo& args);
+        Value ButtplugClientProtobufMessage(const CallbackInfo& args);
+        Value ButtplugCreateDevice(const CallbackInfo& args);
+        Value ButtplugFreeDevice(const CallbackInfo& args);
+        Value ButtplugDeviceProtobufMessage(const CallbackInfo& args);
+        Value ButtplugActivateEnvLogger(const CallbackInfo& args);
+
+        bool HasClientOrDevice(uint32_t id);
+
+        uint32_t AddClient(void* client_ptr, Callback* cb);
+        void DeleteClient(uint32_t client_id);
+        void* GetClient(uint32_t client_id);
+
+        uint32_t AddDevice(void* device_ptr);
+        void DeleteDevice(uint32_t device_id);
+        void* GetDevice(uint32_t device_id);
+
+        #define DEF_DLL_FUNCTION(name) DLL_FUNC_TYPE(name) DLL_FUNC_VAR(name) = nullptr;
+        BUTTPLUG_RS_FFI_FUNCTION_LIST(DEF_DLL_FUNCTION)
+        #undef DEF_DLL_FUNCTION
+
+        bool initialized = false;
+        void* module = nullptr;
+        std::unordered_map<uint32_t, ClientData*> id_to_client_data;
+        std::unordered_map<uint32_t, void*> id_to_device_ptr;
+        std::random_device rd;
+        std::mt19937 rnd;
+};
+
+ButtplugAddon::ButtplugAddon(Env env, Object exports) :
+    id_to_client_data(),
+    id_to_device_ptr(),
+    Addon<ButtplugAddon>()
+{
+    rnd = std::mt19937(rd());
+    DefineAddon(exports, {
+        InstanceMethod("buttplug_initialize", &ButtplugAddon::Initialize),
+        InstanceMethod("buttplug_create_protobuf_client", &ButtplugAddon::ButtplugCreateProtobufClient),
+        InstanceMethod("buttplug_free_client", &ButtplugAddon::ButtplugFreeClient),
+        InstanceMethod("buttplug_client_protobuf_message", &ButtplugAddon::ButtplugClientProtobufMessage),
+        InstanceMethod("buttplug_create_device", &ButtplugAddon::ButtplugCreateDevice),
+        InstanceMethod("buttplug_free_device", &ButtplugAddon::ButtplugFreeDevice),
+        InstanceMethod("buttplug_device_protobuf_message", &ButtplugAddon::ButtplugDeviceProtobufMessage),
+        InstanceMethod("buttplug_activate_env_logger", &ButtplugAddon::ButtplugActivateEnvLogger),
+    });
+}
+
+ButtplugAddon::~ButtplugAddon() {
+    if (!initialized) return;
+    initialized = false;
+
+    // close all devices
+    for (auto it : id_to_device_ptr) {
+        _buttplug_free_device(it.second);
+    }
+    id_to_device_ptr.clear();
+
+    // close all clients
+    for (auto it : id_to_client_data) {
+        ClientData* client = it.second;
+        _buttplug_free_client(client->client_ptr);
+        client->cb->tsfn.Release();
+        delete client->cb;
+        delete client;
+    }
+
+    id_to_client_data.clear();
+
+    // release ffi library
+    if (module != nullptr) {
+        #define CLEAR_DLL_FUNCTION(name) DLL_FUNC_VAR(name) = nullptr;
+        BUTTPLUG_RS_FFI_FUNCTION_LIST(CLEAR_DLL_FUNCTION)
+        #undef CLEAR_DLL_FUNCTION
+
+        dlclose(module);
+        module = nullptr;
+    }
+}
+
+// Initializes the addon with options that can be used to locate the ffi library
+Value ButtplugAddon::Initialize(const CallbackInfo& args) {
+    Env env = args.Env();
+    if (initialized) return Boolean::New(env, initialized);
+    if (!args[0].IsObject()) throw TypeError::New(env, "Invalid argument: options. Object expected.");
+
+    Object options = args[0].As<Object>();
+
+    Value fileValue = options.Get("file");
+    if (!fileValue.IsString()) throw TypeError::New(env, "Invalid argument: options. A string-valued property named 'file' is required.");
+
+    std::string file = fileValue.As<String>();
+
+    // Ensure the correct directory separator token
+    #ifdef WIN32
+    std::replace(file.begin(), file.end(), '/', '\\');
+    #else
+    std::replace(file.begin(), file.end(), '\\', '/');
+    #endif
+
+    // Open the ffi library
+    module = dlopen(file.c_str(), 0);
+    if (module == nullptr) {
+        module = dlopen((file + ".dll").c_str(), 0);
+        #ifdef WIN32
+        if (module == nullptr && GetLastError() == 126) {
+            throw TypeError::New(env, "Invalid attempt to load a 32-bit assembly into a 64-bit process");
+        }
+        #endif
+    }
+    if (module == nullptr) {
+        module = dlopen((file + ".so").c_str(), 0);
+    }
+    if (module == nullptr) {
+        module = dlopen((file + ".dylib").c_str(), 0);
+    }
+    if (module == nullptr) {
+        throw TypeError::New(env, "Failed to load '" + file + "': " + dlerror());
+    }
+
+    // Dynamically load each function
+    #define LOAD_DLL_FUNC(name) DLL_FUNC_VAR(name) = reinterpret_cast<DLL_FUNC_TYPE(name)>(dlsym(module, #name));
+    BUTTPLUG_RS_FFI_FUNCTION_LIST(LOAD_DLL_FUNC)
+    #undef LOAD_DLL_FUNC
+
+    // Check that each function was loaded correctly
+    #define DLL_FUNC_LOADED(name) (DLL_FUNC_VAR(name) != nullptr) &&
+    bool result = BUTTPLUG_RS_FFI_FUNCTION_LIST(DLL_FUNC_LOADED) true;
+    #undef DLL_FUNC_LOADED
+
+    initialized = result;
+    return Boolean::New(env, result);
+}
+
+// Tests whether a client or device id has already been registered. This
+// helps to prevent inadvertently passing a client pointer to a device function
+// and vice versa.
+bool ButtplugAddon::HasClientOrDevice(uint32_t id) {
+    if (id_to_client_data.find(id) != id_to_client_data.end()) return true;
+    if (id_to_device_ptr.find(id) != id_to_device_ptr.end()) return true;
+    return false;
+}
+
+// A 64-bit pointer may fall outside the range of a JS Number. As a result,
+// we store the client pointer and callback in an unordered map associated
+// with a unique 32-bit client id.
+uint32_t ButtplugAddon::AddClient(void* client_ptr, Callback* cb) {
+    if (client_ptr == nullptr) return 0;
+    uint32_t client_id = static_cast<uint32_t>(rnd());
+    while (client_id == 0 || HasClientOrDevice(client_id)) {
+        client_id = static_cast<uint32_t>(rnd());
+    }
+    ClientData* client = new ClientData(client_ptr, cb);
+    id_to_client_data.emplace(client_id, client);
+    return client_id;
+}
+
+// Deletes a registered client pointer and releases the callback function
+// associated with the client.
+void ButtplugAddon::DeleteClient(uint32_t client_id) {
+    if (client_id == 0) return;
+    auto it = id_to_client_data.find(client_id);
+    if (it != id_to_client_data.end()) {
+        ClientData* client = it->second;
+        id_to_client_data.erase(it);
+
+        client->cb->tsfn.Release();
+        delete client->cb;
+        delete client;
+    }
+}
+
+// Gets the client pointer for the provided client id
+void* ButtplugAddon::GetClient(uint32_t client_id) {
+    if (client_id == 0) return nullptr;
+    auto it = id_to_client_data.find(client_id);
+    if (it != id_to_client_data.end()) {
+        return it->second->client_ptr;
+    }
+    return nullptr;
+}
+
+// A 64-bit pointer may fall outside the range of a JS Number. As a result,
+// we store the device pointer in an unordered map associated with a unique
+// 32-bit device id.
+uint32_t ButtplugAddon::AddDevice(void* device_ptr) {
+    if (device_ptr == nullptr) return 0;
+    uint32_t device_id = static_cast<uint32_t>(rnd());
+    while (device_id == 0 || HasClientOrDevice(device_id)) {
+        device_id = static_cast<uint32_t>(rnd());
+    }
+    id_to_device_ptr.emplace(device_id, device_ptr);
+    return device_id;
+}
+
+// Deletes a registered device pointer.
+void ButtplugAddon::DeleteDevice(uint32_t device_id) {
+    if (device_id == 0) return;
+    auto it = id_to_device_ptr.find(device_id);
+    if (it != id_to_device_ptr.end()) {
+        id_to_device_ptr.erase(it);
+    }
+}
+
+// Gets the device pointer for the provided device id
+void* ButtplugAddon::GetDevice(uint32_t device_id) {
+    if (device_id == 0) return nullptr;
+    auto it = id_to_device_ptr.find(device_id);
+    if (it != id_to_device_ptr.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
+// Marshals message callbacks from the ffi library back to JS
+void MessageCallback(void* ctx, const uint8_t *buf, uint32_t buf_len) {
+    Callback* cb = static_cast<Callback*>(ctx);
+
+    // Make a mutable copy of the buffer we can send to V8
+    uint8_t* data = (uint8_t*) std::malloc(buf_len * sizeof(uint8_t));
+    std::memcpy(data, buf, buf_len * sizeof(uint8_t));
+
+    // Invoke the callback on the JS event loop
+    cb->tsfn.BlockingCall(data, [=] (Env env, Function callback, uint8_t* data) {
+        Buffer<uint8_t> array = Buffer<uint8_t>::New(env, data, buf_len, [] (auto env, auto data) {
+            UNREFERENCED_PARAMETER(env);
+            std::free(data);
+        });
+
+        callback.Call({ array });
+
+        // If the callback is not persistent, we can delete it here.
+        if (!cb->persistent) {
+            cb->tsfn.Release();
+            delete cb;
+        }
+    });
+}
+
+Value ButtplugAddon::ButtplugCreateProtobufClient(const CallbackInfo& args) {
+    Env env = args.Env();
+    if (!initialized) throw TypeError::New(env, "Unable to load buttplug_rs_ffi");
+    if (!args[0].IsString()) throw TypeError::New(env, "Invalid argument: client_name. String expected.");
+    if (!args[1].IsFunction()) throw TypeError::New(env, "Invalid argument: callback. Function expected.");
+
+    PCSTR client_name = args[0].ToString().Utf8Value().c_str();
+    Function callback = args[1].As<Function>();
+
+    // The callback passed to `buttplug_create_protobuf_client` is persistent until the client is freed.
+    Callback* cb = new Callback(env, callback, "buttplug_create_protobuf_client", /*persistent*/ true);
+
+    void* client_ptr = _buttplug_create_protobuf_client(client_name, MessageCallback, cb);
+    uint32_t client_id = AddClient(client_ptr, cb);
+
+    return Number::New(env, client_id);
+}
+
+Value ButtplugAddon::ButtplugFreeClient(const CallbackInfo& args) {
+    Env env = args.Env();
+    if (!initialized) throw TypeError::New(env, "Unable to load buttplug_rs_ffi");
+    if (!args[0].IsNumber()) throw TypeError::New(env, "Invalid argument: client_ptr. Number expected.");
+
+    uint32_t client_id = args[0].As<Number>().Uint32Value();
+    void* client_ptr = GetClient(client_id);
+
+    if (client_ptr == nullptr) throw TypeError::New(env, "Invalid argument: client_ptr. Argument was not a valid handle.");
+
+    _buttplug_free_client(client_ptr);
+    DeleteClient(client_id);
+
+    return env.Undefined();
+}
+
+Value ButtplugAddon::ButtplugClientProtobufMessage(const CallbackInfo& args) {
+    Env env = args.Env();
+    if (!initialized) throw TypeError::New(env, "Unable to load buttplug_rs_ffi");
+    if (!args[0].IsNumber()) throw TypeError::New(env, "Invalid argument: client_ptr. Number expected.");
+    if (!args[1].IsBuffer()) throw TypeError::New(env, "Invalid argument: buf. Buffer expected.");
+    if (!args[2].IsFunction()) throw TypeError::New(env, "Invalid argument: callback. Function expected.");
+
+    uint32_t client_id = args[0].As<Number>().Uint32Value();
+    void* client_ptr = GetClient(client_id);
+
+    if (client_ptr == nullptr) throw TypeError::New(env, "Invalid argument: client_ptr. Argument was not a valid handle.");
+
+    Buffer<uint8_t> buf = args[1].As<Buffer<uint8_t>>();
+    Function callback = args[2].As<Function>();
+
+    // The callback passed to `buttplug_client_protobuf_message` is single use.
+    Callback* cb = new Callback(env, callback, "buttplug_client_protobuf_message", /*persistent*/ false);
+
+    _buttplug_client_protobuf_message(client_ptr, buf.Data(), buf.ByteLength(), MessageCallback, cb);
+
+    return env.Undefined();
+}
+
+Value ButtplugAddon::ButtplugCreateDevice(const CallbackInfo& args) {
+    Env env = args.Env();
+    if (!initialized) throw TypeError::New(env, "Unable to load buttplug_rs_ffi");
+    if (!args[0].IsNumber()) throw TypeError::New(env, "Invalid argument: client_ptr. Number expected.");
+    if (!args[1].IsNumber()) throw TypeError::New(env, "Invalid argument: device_index. Number expected.");
+
+    uint32_t client_id = args[0].As<Number>().Uint32Value();
+    uint32_t device_index = args[1].As<Number>().Uint32Value();
+    void* client_ptr = GetClient(client_id);
+
+    if (client_ptr == nullptr) throw TypeError::New(env, "Invalid argument: client_ptr. Argument was not a valid handle.");
+
+    void* device_ptr = _buttplug_create_device(client_ptr, device_index);
+    uint32_t device_id = AddDevice(device_ptr);
+
+    return Number::New(env, device_id);
+}
+
+Value ButtplugAddon::ButtplugFreeDevice(const CallbackInfo& args) {
+    Env env = args.Env();
+    if (!initialized) throw TypeError::New(env, "Unable to load buttplug_rs_ffi");
+    if (!args[0].IsNumber()) throw TypeError::New(env, "Invalid argument: client_ptr. Number expected.");
+
+    uint32_t device_id = args[0].As<Number>().Uint32Value();
+    void* device_ptr = GetDevice(device_id);
+
+    if (device_ptr == nullptr) throw TypeError::New(env, "Invalid argument: device_ptr. Argument was not a valid handle.");
+
+    _buttplug_free_device(device_ptr);
+    DeleteDevice(device_id);
+
+    return env.Undefined();
+}
+
+Value ButtplugAddon::ButtplugDeviceProtobufMessage(const CallbackInfo& args) {
+    Env env = args.Env();
+    if (!initialized) throw TypeError::New(env, "Unable to load buttplug_rs_ffi");
+    if (!args[0].IsNumber()) throw TypeError::New(env, "Invalid argument: device_ptr. Number expected.");
+    if (!args[1].IsBuffer()) throw TypeError::New(env, "Invalid argument: buf. Buffer expected.");
+    if (!args[2].IsFunction()) throw TypeError::New(env, "Invalid argument: callback. Function expected.");
+
+    uint32_t device_id = args[0].As<Number>().Uint32Value();
+    void* device_ptr = GetDevice(device_id);
+
+    if (device_ptr == nullptr) throw TypeError::New(env, "Invalid argument: device_ptr. Argument was not a valid handle.");
+
+    Buffer<uint8_t> buf = args[1].As<Buffer<uint8_t>>();
+    Function callback = args[2].As<Function>();
+
+    // The callback passed to `buttplug_device_protobuf_message` is single use.
+    Callback* cb = new Callback(env, callback, "buttplug_device_protobuf_message", /*persistent*/ false);
+
+    _buttplug_device_protobuf_message(device_ptr, buf.Data(), buf.ByteLength(), MessageCallback, cb);
+
+    return env.Undefined();
+}
+
+Value ButtplugAddon::ButtplugActivateEnvLogger(const CallbackInfo& args) {
+    Env env = args.Env();
+    if (!initialized) throw TypeError::New(env, "Unable to load buttplug_rs_ffi");
+
+    _buttplug_activate_env_logger();
+
+    return env.Undefined();
+}
+
+NODE_API_ADDON(ButtplugAddon);

--- a/js/src/node/binding.h
+++ b/js/src/node/binding.h
@@ -1,0 +1,21 @@
+#ifndef BINDING_H
+#define BINDING_H
+
+#include <string>
+#include <random>
+#include <mutex>
+#include <uv.h>
+#include <node.h>
+#include <napi.h>
+#include <unordered_map>
+
+#ifdef WIN32
+#include "win32-dlfcn.h"
+#else
+#include <dlfcn.h>
+#endif
+
+using namespace Napi;
+
+#endif
+

--- a/js/src/node/ffi_wrap.ts
+++ b/js/src/node/ffi_wrap.ts
@@ -1,0 +1,32 @@
+import node_gyp_build from "node-gyp-build";
+import { URL, fileURLToPath } from "url";
+import path from "path";
+
+// NOTE: path is relative to ~/dist/node not ~/src
+const packageDir = fileURLToPath(new URL("../../..", import.meta.url));
+const bindings = node_gyp_build(packageDir) as Bindings;
+
+interface Bindings {
+    buttplug_initialize: (options: { file: string }) => void;
+    buttplug_create_protobuf_client: (client_name: string, callback: (buf: Uint8Array) => void, callback_context: any) => number;
+    buttplug_free_client: (client_ptr: number) => void;
+    buttplug_client_protobuf_message: (client_ptr: number, buf: Uint8Array, callback: (buf: Uint8Array) => void, callback_context: any) => void;
+    buttplug_create_device: (client_ptr: number, device_index: number) => number;
+    buttplug_free_device: (device_ptr: number) => void;
+    buttplug_device_protobuf_message: (device_ptr: number, buf: Uint8Array, callback: (buf: Uint8Array) => void, callback_context: any) => void;
+    buttplug_activate_env_logger: (log_level?: string) => void;
+}
+
+const file = path.join(packageDir, "bin", `${process.platform}-${process.arch}`, "buttplug_rs_ffi");
+export const initialized = bindings.buttplug_initialize({ file });
+export const buttplug_create_protobuf_client: (client_name: string, callback: (buf: Uint8Array) => void, callback_context: any) => number = bindings.buttplug_create_protobuf_client.bind(bindings);
+export const buttplug_free_client: (client_ptr: number) => void = bindings.buttplug_free_client.bind(bindings);
+export const buttplug_client_protobuf_message: (client_ptr: number, buf: Uint8Array, callback: (buf: Uint8Array) => void, callback_context: any) => void = bindings.buttplug_client_protobuf_message.bind(bindings);
+export const buttplug_create_device: (client_ptr: number, device_index: number) => number = bindings.buttplug_create_device.bind(bindings);
+export const buttplug_free_device: (device_ptr: number) => void = bindings.buttplug_free_device.bind(bindings);
+export const buttplug_device_protobuf_message: (device_ptr: number, buf: Uint8Array, callback: (buf: Uint8Array) => void, callback_context: any) => void = bindings.buttplug_device_protobuf_message.bind(bindings);
+export const buttplug_activate_env_logger: (log_level?: string) => void = bindings.buttplug_activate_env_logger.bind(bindings);
+
+export async function buttplugInit() {
+    // does nothing
+}

--- a/js/src/node/win32-dlfcn.cpp
+++ b/js/src/node/win32-dlfcn.cpp
@@ -1,0 +1,171 @@
+/**
+ * @file Minimal emulation of POSIX dlopen/dlsym/dlclose on Windows.
+ * @license Public domain.
+ *
+ * This code works fine for the common scenario of loading a
+ * specific DLL and calling one (or more) functions within it.
+ *
+ * No attempt is made to emulate POSIX symbol table semantics.
+ * The way Windows thinks about dynamic linking is fundamentally
+ * different, and there's no way to emulate the useful aspects of
+ * POSIX semantics.
+ */
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+#include <stdio.h>
+#include <malloc.h>
+
+#include "win32-dlfcn.h"
+
+/**
+ * Win32 error code from last failure.
+ */
+
+static DWORD lastError = 0;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Convert UTF-8 string to Windows UNICODE (UCS-2 LE).
+ *
+ * Caller must free() the returned string.
+ */
+
+static
+WCHAR*
+UTF8toWCHAR(
+    const char* inputString /** UTF-8 string. */
+)
+{
+    int outputSize;
+    WCHAR* outputString;
+
+    outputSize = MultiByteToWideChar(CP_UTF8, 0, inputString, -1, NULL, 0);
+
+    if (outputSize == 0)
+        return NULL;
+
+    outputString = (WCHAR*) malloc(outputSize * sizeof(WCHAR));
+
+    if (outputString == NULL) {
+        SetLastError(ERROR_OUTOFMEMORY);
+        return NULL;
+    }
+
+    if (MultiByteToWideChar(CP_UTF8, 0, inputString, -1, outputString, outputSize) != outputSize)
+    {
+        free(outputString);
+        return NULL;
+    }
+
+    return outputString;
+}
+
+/**
+ * Open DLL, returning a handle.
+ */
+
+void*
+dlopen(
+    const char* file,   /** DLL filename (UTF-8). */
+    int mode            /** mode flags (ignored). */
+)
+{
+    WCHAR* unicodeFilename;
+    UINT errorMode;
+    void* handle;
+
+    UNREFERENCED_PARAMETER(mode);
+
+    if (file == NULL)
+        return (void*) GetModuleHandle(NULL);
+
+    unicodeFilename = UTF8toWCHAR(file);
+
+    if (unicodeFilename == NULL) {
+        lastError = GetLastError();
+        return NULL;
+    }
+
+    errorMode = GetErrorMode();
+
+    /* Have LoadLibrary return NULL on failure; prevent GUI error message. */
+    SetErrorMode(errorMode | SEM_FAILCRITICALERRORS);
+
+    handle = (void*) LoadLibraryW(unicodeFilename);
+
+    if (handle == NULL)
+        lastError = GetLastError();
+
+    SetErrorMode(errorMode);
+
+    free(unicodeFilename);
+
+    return handle;
+}
+
+/**
+ * Close DLL.
+ */
+
+int
+dlclose(
+    void* handle        /** Handle from dlopen(). */
+)
+{
+    int rc = 0;
+
+    if (handle != (void*) GetModuleHandle(NULL))
+        rc = !FreeLibrary((HMODULE) handle);
+
+    if (rc)
+        lastError = GetLastError();
+
+    return rc;
+}
+
+/**
+ * Look up symbol exported by DLL.
+ */
+
+void*
+dlsym(
+    void* handle,       /** Handle from dlopen(). */
+    const char* name    /** Name of exported symbol (ASCII). */
+)
+{
+    void* address = (void*) GetProcAddress((HMODULE) handle, name);
+
+    if (address == NULL)
+        lastError = GetLastError();
+
+    return address;
+}
+
+/**
+ * Return message describing last error.
+ */
+
+char*
+dlerror(void)
+{
+    static char errorMessage[64];
+
+    if (lastError != 0) {
+        sprintf(errorMessage, "Win32 error %lu", lastError);
+        lastError = 0;
+        return errorMessage;
+    } else {
+        return NULL;
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/js/src/node/win32-dlfcn.h
+++ b/js/src/node/win32-dlfcn.h
@@ -1,0 +1,65 @@
+/**
+ * @file Minimal emulation of POSIX dlopen/dlsym/dlclose on Windows.
+ * @license Public domain.
+ *
+ * This code works fine for the common scenario of loading a
+ * specific DLL and calling one (or more) functions within it.
+ * No attempt is made to emulate POSIX symbol table semantics.
+ */
+
+#ifndef _INCLUDE_DLFCN_H_
+#define _INCLUDE_DLFCN_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RTLD_LAZY       0
+#define RTLD_NOW        0
+#define RTLD_GLOBAL     0
+#define RTLD_LOCAL      0
+
+#define RTLD_DEFAULT    ((void*) NULL)
+#define RTLD_NEXT       ((void*) NULL)
+
+/**
+ * Open DLL, returning a handle.
+ */
+
+void*
+dlopen(
+    const char *file,   /** DLL filename. */
+    int mode            /** mode flags (ignored). */
+);
+
+/**
+ * Close DLL.
+ */
+
+int
+dlclose(
+    void* handle        /** Handle from dlopen(). */
+);
+
+/**
+ * Look up symbol exported by DLL.
+ */
+
+void*
+dlsym(
+    void* handle,       /** Handle from dlopen(). */
+    const char* name    /** Name of exported symbol. */
+);
+
+/**
+ * Return message describing last error.
+ */
+
+char*
+dlerror(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/js/tsconfig.base.json
+++ b/js/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions" : {
+    "baseUrl": "./src",
+    "lib": ["esnext", "dom"],
+    "target": "es2018",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "declaration": true,
+    "outDir": "./dist/module",
+    "esModuleInterop": true,
+  }
+}

--- a/js/tsconfig.browser.json
+++ b/js/tsconfig.browser.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions" : {
+    "outDir": "./dist/browser",
+  },
+  "include": [
+    "./src/**/*",
+    "./tests/**/*.ts"
+  ],
+  "exclude": [
+    "./src/node"
+  ]
+}

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -1,21 +1,3 @@
 {
-  "compilerOptions" : {
-    "baseUrl": "./src",
-    "lib": ["es2015", "dom", "es6"],
-    "target": "es2018",
-    "module": "esnext",
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "declaration": true,
-    "outDir": "./dist/module",
-    "esModuleInterop": true,
-  },
-  "include": [
-    "./src/**/*",
-    "./tests/**/*.ts"
-  ]
+  "extends": "./tsconfig.node.json"
 }

--- a/js/tsconfig.node.json
+++ b/js/tsconfig.node.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions" : {
+    "outDir": "./dist/node",
+  },
+  "include": [
+    "./src/**/*",
+    "./tests/**/*.ts"
+  ],
+  "exclude": [
+    "./src/web_index.ts",
+    "./src/browser"
+  ]
+}

--- a/js/webpack.base.cjs
+++ b/js/webpack.base.cjs
@@ -18,7 +18,7 @@ const base = {
   },
   entry: path.resolve('./src/web_index.ts'),
   output: {
-    path: path.resolve('./dist/web'),
+    path: path.resolve('./dist/browser'),
     filename: 'buttplug.js',
     libraryTarget: 'umd',
     library: {
@@ -38,7 +38,8 @@ const base = {
         use: [{
           loader: 'ts-loader',
           options: {
-            transpileOnly: true
+            transpileOnly: true,
+            configFile: "tsconfig.browser.json"
           }
         }]
       }
@@ -73,8 +74,8 @@ const base = {
     // we are running in NodeJS or in the browser. The following rewrites the import
     // mapping for '#buttplug_rs_ffi_bg' to point to the webpack-compatible version.
     new webpack.NormalModuleReplacementPlugin(/^#/, resource => {
-      if (resource.request === "#buttplug_rs_ffi_bg") {
-        resource.request = path.join(__dirname, "src/buttplug-rs-ffi/buttplug_rs_ffi_bg_web.js");
+      if (resource.request === "#ffi_wrap") {
+        resource.request = path.join(__dirname, "src/browser/ffi_wrap.ts");
       }
     }),
   ]

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -104,6 +104,11 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-13.13.34.tgz"
   integrity sha512-g8D1HF2dMDKYSDl5+79izRwRgNPsSynmWMbj50mj7GZ0b7Lv4p8EmZjbo3h0h+6iLr6YmVz9VnF6XVZ3O6V1Ug==
 
+"@types/node@15":
+  version "15.12.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.5.tgz#9a78318a45d75c9523d2396131bd3cca54b2d185"
+  integrity sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==
+
 "@types/object-hash@^1.3.0":
   version "1.3.4"
   resolved "https://registry.npmjs.org/@types/object-hash/-/object-hash-1.3.4.tgz"
@@ -469,7 +474,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -513,6 +518,15 @@ bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 bluebird@^3.5.5:
   version "3.7.2"
@@ -677,6 +691,14 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 bufferutil@^4.0.1:
   version "4.0.3"
@@ -1169,7 +1191,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
 
 debug@^3.1.1, debug@^3.2.6:
   version "3.2.7"
-  resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
@@ -1418,7 +1440,7 @@ encodeurl@~1.0.2:
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -1594,6 +1616,13 @@ execa@^1.0.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+execspawn@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/execspawn/-/execspawn-1.0.1.tgz#8286f9dde7cecde7905fbdc04e24f368f23f8da6"
+  integrity sha1-gob53efOzeeQX73ATiTzaPI/jaY=
+  dependencies:
+    util-extend "^1.0.1"
 
 expand-brackets@^2.1.4:
   version "2.1.4"
@@ -1830,6 +1859,11 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-extra@^9.0.0:
   version "9.0.1"
@@ -2212,7 +2246,7 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -2865,6 +2899,11 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
 mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
@@ -2967,12 +3006,24 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-abi@^2.19.1:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.30.0.tgz#8be53bf3e7945a34eea10e0fc9a5982776cf550b"
+  integrity sha512-g6bZh3YCKQRdwuO/tSZZYJAw622SjsRfJ2X0Iy4sSOHZ34/sPPdVBn8fev2tj7njzLwuqPw9uMtGsGkO5kIQvg==
+  dependencies:
+    semver "^5.4.1"
+
+node-addon-api@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.0.0.tgz#ac128f43eff7fac4b5f5ef2f39d6d7c2709efead"
+  integrity sha512-ALmRVBFzfwldBfk3SbKfl6+PVMXiCPKZBEfsJqB/EjXAMAI+MfFrEHR+GMRBuI162DihZ1QjEZ8ieYKuRCJ8Hg==
+
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
-node-gyp-build@^4.2.0:
+node-gyp-build@^4.2.0, node-gyp-build@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
   integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
@@ -3032,6 +3083,13 @@ npm-run-path@^2.0.0:
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
+
+npm-run-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-3.1.0.tgz#7f91be317f6a466efed3c9f2980ad8a4ee8b0fa5"
+  integrity sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==
+  dependencies:
+    path-key "^3.0.0"
 
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
@@ -3276,7 +3334,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-key@^3.1.0:
+path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
@@ -3349,6 +3407,19 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
+prebuildify@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/prebuildify/-/prebuildify-4.1.2.tgz#b4eec5d9aa01d291d0be4a93fafeec62dfdda514"
+  integrity sha512-KEICWdLcz37OAVXcyf/h3y4FbUG/tUF+C7y/CJzHp6lZA1+T/obLLThd7w5vQHf1tr31CNDI34wKZUVT0hL2vw==
+  dependencies:
+    execspawn "^1.0.1"
+    minimist "^1.2.5"
+    mkdirp-classic "^0.5.3"
+    node-abi "^2.19.1"
+    npm-run-path "^3.1.0"
+    pump "^3.0.0"
+    tar-fs "^2.1.0"
 
 prettier@^2.0.2:
   version "2.2.1"
@@ -3517,7 +3588,7 @@ raw-body@2.4.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6, readable-stream@^3.6.0:
+readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -3733,7 +3804,7 @@ selfsigned@^1.10.8:
   dependencies:
     node-forge "^0.10.0"
 
-semver@^5.5.0, semver@^5.6.0:
+semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -4150,6 +4221,27 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+tar-fs@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
 terser-webpack-plugin@^1.4.3:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz#a217aefaea330e734ffacb6120ec1fa312d6040b"
@@ -4333,10 +4425,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz"
-  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+typescript@4.3:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 uglify-js@^3.12.7:
   version "3.12.7"
@@ -4444,6 +4536,11 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+util-extend@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/util-extend/-/util-extend-1.0.3.tgz#a7c216d267545169637b3b6edc6ca9119e2ff93f"
+  integrity sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=
 
 util@0.10.3:
   version "0.10.3"


### PR DESCRIPTION
This adds native bindings for NodeJS, instead of depending on a WASM build. The WASM build is still used for the browser. I also added a script to run on `npm install` that will fetch a specific release build (configured in `package.json` as `"ffi-version"`).

Also, it is no longer necessary to invoke `buttplugInit()` in NodeJS (though it is still necessary in the browser).

There are a few things that still need to be worked out and tested:
- Testing prebuilds of the bindings.
- Testing on other OSes (only tested in Windows so far)
- I could not get rust to build x64 dll on Windows for some reason, so the script currently fetches a release build. I'm not familiar enough with Rust to resolve this currently.
