### PR TITLE
fix: Revert "js: Add url to wasm file as argument to buttplugInit"

### DIFF
--- a/js/src/ffi.ts
+++ b/js/src/ffi.ts
@@ -29,12 +29,12 @@ let buttplug_create_device = must_run_init_2;
 let buttplug_device_protobuf_message = must_run_init_4;
 let buttplug_has_init_run = false;
 
-export async function buttplugInit(url: string = "./buttplug-rs-ffi/buttplug_rs_ffi.js") {
+export async function buttplugInit() {
   if (buttplug_has_init_run) {
     console.log("buttplugInit function has already run successfully. This only needs to be run once, but doesn't affect anything (other than printing this message) if called again.");
     return;
   }
-  let index = await import(/* webpackPrefetch: 1 */ url).catch((e) => {
+  let index = await import(/* webpackPrefetch: 1 */ "./buttplug-rs-ffi/buttplug_rs_ffi.js").catch((e) => {
     console.log(e);
     return Promise.reject(e);
   });


### PR DESCRIPTION
This fixes #88 by reverting commit fe66645f19e43682b55ebfd51a2979036803b4d8

That change was supposed to make it possible to override the location of the
Buttplug JS files, but instead it prevents a webpack path rewriting feature
from working so that without a path, the library is no longer able to find
the files to import.

Worse, due to a mix of JS and WASM and import statements between them, it's
not actually possible to specify a path to a the Buttplug JS files and have
a browser load them: doing so just results in MIME type checking errors.