### PR TITLE
Move exception catch for missing natives

### DIFF
--- a/java/lib/src/main/java/io/buttplug/ButtplugClient.java
+++ b/java/lib/src/main/java/io/buttplug/ButtplugClient.java
@@ -79,7 +79,7 @@ public class ButtplugClient implements AutoCloseable {
         try {
             this.pointer = ButtplugFFI.buttplug_create_protobuf_client(client_name, systemCallback, systemCallbackCtx);
         } catch (Throwable ex) {
-            throw new RuntimeException("Missing natives for platform: '" + Platform.RESOURCE_PREFIX + "'", ex);
+            throw new RuntimeException("Failed to load natives for platform: '" + Platform.RESOURCE_PREFIX + "'", ex);
         }
         this.name = client_name;
     }

--- a/java/lib/src/main/java/io/buttplug/ButtplugClient.java
+++ b/java/lib/src/main/java/io/buttplug/ButtplugClient.java
@@ -1,6 +1,7 @@
 package io.buttplug;
 
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import io.buttplug.exceptions.ButtplugDeviceException;
 import io.buttplug.exceptions.ButtplugException;
@@ -75,7 +76,11 @@ public class ButtplugClient implements AutoCloseable {
 
     public ButtplugClient(String client_name) {
         systemCallbackCtx = clientReferenceManager.add(this);
-        this.pointer = ButtplugFFI.buttplug_create_protobuf_client(client_name, systemCallback, systemCallbackCtx);
+        try {
+            this.pointer = ButtplugFFI.buttplug_create_protobuf_client(client_name, systemCallback, systemCallbackCtx);
+        } catch (Throwable ex) {
+            throw new RuntimeException("Missing natives for platform: '" + Platform.RESOURCE_PREFIX + "'", ex);
+        }
         this.name = client_name;
     }
 

--- a/java/lib/src/main/java/io/buttplug/ButtplugFFI.java
+++ b/java/lib/src/main/java/io/buttplug/ButtplugFFI.java
@@ -63,10 +63,6 @@ public class ButtplugFFI {
     static native void buttplug_activate_env_logger();
 
     static {
-        try {
-            Native.register("buttplug_rs_ffi");
-        } catch (Throwable ex) {
-            throw new RuntimeException("Missing natives for platform: '" + Platform.RESOURCE_PREFIX + "'", ex);
-        }
+        Native.register("buttplug_rs_ffi");
     }
 }

--- a/java/lib/src/main/java/io/buttplug/ButtplugLogHandler.java
+++ b/java/lib/src/main/java/io/buttplug/ButtplugLogHandler.java
@@ -30,7 +30,7 @@ public class ButtplugLogHandler implements AutoCloseable {
         try {
             ButtplugFFI.buttplug_activate_env_logger();
         } catch (Throwable ex) {
-            throw new RuntimeException("Missing natives for platform: '" + Platform.RESOURCE_PREFIX + "'", ex);
+            throw new RuntimeException("Failed to load natives for platform: '" + Platform.RESOURCE_PREFIX + "'", ex);
         }
     }
 
@@ -70,7 +70,7 @@ public class ButtplugLogHandler implements AutoCloseable {
             log_handle = ButtplugFFI
                     .buttplug_create_log_handle(callback, null, level.value, use_json);
         } catch (Throwable ex) {
-            throw new RuntimeException("Missing natives for platform: '" + Platform.RESOURCE_PREFIX + "'", ex);
+            throw new RuntimeException("Failed to load natives for platform: '" + Platform.RESOURCE_PREFIX + "'", ex);
         }
     }
 

--- a/java/lib/src/main/java/io/buttplug/ButtplugLogHandler.java
+++ b/java/lib/src/main/java/io/buttplug/ButtplugLogHandler.java
@@ -1,5 +1,6 @@
 package io.buttplug;
 
+import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -26,7 +27,11 @@ public class ButtplugLogHandler implements AutoCloseable {
         if (!logHandlerActive.compareAndSet(false, true)) {
             throw new IllegalStateException("There is already an active log handler!");
         }
-        ButtplugFFI.buttplug_activate_env_logger();
+        try {
+            ButtplugFFI.buttplug_activate_env_logger();
+        } catch (Throwable ex) {
+            throw new RuntimeException("Missing natives for platform: '" + Platform.RESOURCE_PREFIX + "'", ex);
+        }
     }
 
     public enum Level {
@@ -61,8 +66,12 @@ public class ButtplugLogHandler implements AutoCloseable {
         }
 
         callback = (ctx, str) -> cb.log(str);
-        log_handle = ButtplugFFI
-                .buttplug_create_log_handle(callback, null, level.value, use_json);
+        try {
+            log_handle = ButtplugFFI
+                    .buttplug_create_log_handle(callback, null, level.value, use_json);
+        } catch (Throwable ex) {
+            throw new RuntimeException("Missing natives for platform: '" + Platform.RESOURCE_PREFIX + "'", ex);
+        }
     }
 
     @Override


### PR DESCRIPTION
This should make the "missing natives" exception more visible, since it'll be closer to the top of the stack.

Also added some handling for setting up a log handler.

while I was working on this, I noticed `callback = (ctx, str) -> cb.log(str);`, which is *not* a static callback like most/every other callback in this library. i should probably fix that at some point.